### PR TITLE
Improve Dev Environment; Decouple Data and Website

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,13 +5,10 @@
 name: Deploy Next.js site to Pages
 
 on:
-  # Run this workflow on the latest-dashboard-data branch when the Fetch CI Nightly Data workflow completes
-  workflow_run:
-    workflows: ["Fetch CI Nightly Data"]
-    types:
-      - completed
+  # When a commit is made to the main branch
+  push:
     branches:
-      - latest-dashboard-data
+      - main
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   reactStrictMode: true,
   output: 'export',
-  basePath: "/kata-dashboard-next",
+  basePath: process.env.NODE_ENV == "development" ? "" : "/kata-dashboard-next",
   images: {
     unoptimized: true,
   }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nextjs-basic",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "NODE_ENV=development next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,8 +1,6 @@
 import { useEffect, useState } from "react";
 import { DataTable } from "primereact/datatable";
 import { Column } from "primereact/column";
-// import { fetchCIData } from "../scripts/fetch-ci-nightly-data";
-import data from "../data/job_stats.json";
 
 export default function Home() {
   const [loading, setLoading] = useState(true);
@@ -20,7 +18,10 @@ export default function Home() {
 
   useEffect(() => {
     const fetchData = async () => {
-      // const data = await fetchCIData();
+      const response = await fetch(
+        "https://raw.githubusercontent.com/a1icja/kata-dashboard-next/refs/heads/latest-dashboard-data/data/job_stats.json"
+      );
+      const data = await response.json();
 
       const jobData = Object.keys(data).map((key) => {
         const job = data[key];
@@ -94,7 +95,8 @@ export default function Home() {
     return (
       <div key={`${job.name}-runs`} className="p-3">
         {runs.map((run) => {
-          const emoji = run.result === "Pass" ? "✅" : run.result === "Fail" ? "❌" : "⚠️";
+          const emoji =
+            run.result === "Pass" ? "✅" : run.result === "Fail" ? "❌" : "⚠️";
           return (
             <span key={`${job.name}-runs-${run.run_num}`}>
               <a href={run.url}>


### PR DESCRIPTION
Added:
- `NODE_ENV` definition for local development

Changed:
- Data source and website are decoupled
  - Data is now fetched from the GitHub repo
- Auto-deploy is now based on the main branch
  - Due to the decoupling of data from site, they can both be updated independently
- Base path is blank for local and `/kata-dashboard-next` for prod
  - This fixes issues with local dev where Next.js would not auto-redirect the developer to the correct base path

---

Tested:

- [x] Locally
- [ ] Remotely (i.e. data updates)
- [ ] Automatically (i.e. via a test suite) 