### PR TITLE
Add Reruns, Maintainers List, URL enhancement/filter box overhaul, fetch script changes, Single PR View

### DIFF
--- a/.github/workflows/fetch-ci-pr-data.yml
+++ b/.github/workflows/fetch-ci-pr-data.yml
@@ -1,5 +1,5 @@
-name: Fetch CI Nightly Data
-run-name: Fetch CI Nightly Data
+name: Fetch CI PR Data
+run-name: Fetch CI PR Data
 on:
   schedule:
     - cron: '0 12 * * *'
@@ -17,8 +17,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Update dashboard data
         run: |
-          # fetch ci nightly data as temporary file
-          node scripts/fetch-ci-nightly-data.js | tee tmp-data.json
+          # fetch ci pr data as temporary file
+          node scripts/fetch-ci-pr-data.js | tee tmp-data2.json
           # switch to a branch specifically for holding latest data
           git config --global user.name "GH Actions Workflow"
           git config --global user.email "<gha@runner>"
@@ -30,8 +30,8 @@ jobs:
           git rm -r --cached data/
           rm -rf data/
           mkdir -p data/
-          mv tmp-data.json data/job_stats.json
+          mv tmp-data2.json data/check_stats.json
           # commit
           git add data
-          git commit -m '[skip ci] latest ci nightly data'
+          git commit -m '[skip ci] latest ci pr data'
           git push --force

--- a/maintainers.yml
+++ b/maintainers.yml
@@ -1,0 +1,77 @@
+# maintainers.yaml
+#
+# @kata-containers/arch-s390x: BbolroC
+# @kata-containers/arch-ppc64le: Amulyam24?
+# @kata-containers/cri-o: ?
+# @kata-containers/dragonball: bergwolf
+# @kata-containers/rust: pmores, lifupan
+# @kata-containers/amd: AdithyaKrishnan, ryansavino
+
+
+## slack: member id, display name, or link to profile?
+
+mappings:
+  # @kata-containers/arch-s390x: BbolroC
+  - regex: ".*s390x.*"
+    owners:
+      - fullname: "Hyounggyu Choi"
+        email: "Hyounggyu.Choi@ibm.com"
+        # slack: "https://katacontainers.slack.com/team/U0369UMM69M"
+        # slack: "U0369UMM69M"
+        slack: "Hyounggyu Choi"
+        github: "BbolroC"
+
+  # @kata-containers/arch-ppc64le: Amulyam24?
+  - regex: ".*ppc64le.*"
+    owners:
+      - fullname: "Amulya Meka"
+        email: "amulmek1@in.ibm.com"
+        # slack: "https://katacontainers.slack.com/team/UV7RP34GK"
+        # slack: "UV7RP34GK"
+        slack: "Amulyam24"
+        github: "Amulyam24"
+
+  # @kata-containers/dragonball: bergwolf
+  - regex: ".*dragonball.*"
+    owners:
+      - fullname: "Peng Tao"
+        email: "http://bergwolf.github.io/"
+        # slack: "https://katacontainers.slack.com/team/U8709NBSM"
+        # slack: "U8709NBSM"
+        slack: "bergwolf"
+        github: "bergwolf"
+
+  # @kata-containers/rust: pmores, lifupan
+  - regex: ".*runtime-rs.*"
+    owners:
+      - fullname: "Pavel Mores"
+        email: "pmores@redhat.com"
+        # slack: "https://katacontainers.slack.com/team/U03CCR6KGBC"
+        # slack: "U03CCR6KGBC"
+        slack: "Pavel Mores"
+        github: "pmores"
+
+      - fullname: "Fupan Li"
+        email: "lifupan@gmail.com"
+        # slack: "https://katacontainers.slack.com/team/U059Y60DZPW"
+        # slack: "U059Y60DZPW"
+        slack: "fupan li"
+        github: "lifupan"
+
+# @kata-containers/amd: AdithyaKrishnan, ryansavino
+  - regex: ".*qemu-(sev|snp).*"
+    owners:
+      - fullname: "Adithya Krishnan Kannan"
+        email: "AdithyaKrishnan.Kannan@amd.com"
+        # slack: "https://cloud-native.slack.com/team/U05TX2URB16"
+        # slack: "U05TX2URB16"
+        slack: "Adi"
+        github: "AdithyaKrishnan"
+
+      - fullname: "Ryan Savino"
+        email: "ryan.savino@amd.com"
+        # slack: "https://cloud-native.slack.com/team/U03CXU0LY79"
+        # slack: "U03CXU0LY79"
+        slack: "Ryan Savino"
+        github: "ryansavino"
+

--- a/next.config.js
+++ b/next.config.js
@@ -6,6 +6,12 @@ module.exports = {
     unoptimized: true,
   },
   webpack: (config, { dev }) => {
+
+    config.module.rules.push({
+      test: /\.yml$/,
+      use: 'yaml-loader',
+    });
+
     if (dev) {
       config.devtool = false;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,12 +6,14 @@
     "": {
       "name": "nextjs-basic",
       "dependencies": {
+        "chart.js": "^4.4.5",
         "dotenv": "^16.4.5",
         "next": "^14.2.13",
         "primeflex": "^3.3.1",
         "primeicons": "^6.0.1",
         "primereact": "^10.8.3",
         "react": "^18.3.1",
+        "react-chartjs-2": "^5.2.0",
         "react-dom": "^18.3.1",
         "react-transition-group": "^4.4.5"
       },
@@ -245,6 +247,11 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.2.tgz",
+      "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw=="
     },
     "node_modules/@next/env": {
       "version": "14.2.13",
@@ -1263,6 +1270,17 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.5.tgz",
+      "integrity": "sha512-CVVjg1RYTJV9OCC8WeJPMx8gsV8K6WIyIEQUE3ui4AR9Hfgls9URri6Ja3hyMVBbTF8Q2KFa19PE815gWcWhng==",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/chokidar": {
@@ -4276,6 +4294,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.2.0.tgz",
+      "integrity": "sha512-98iN5aguJyVSxp5U3CblRLH67J8gkfyGNbiK3c+l1QI/G4irHMPQw44aEPmjVag+YKTyQ260NcF82GTQ3bdscA==",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "nextjs-basic",
       "dependencies": {
+        "dotenv": "^16.4.5",
         "next": "^14.2.13",
         "primeflex": "^3.3.1",
         "primeicons": "^6.0.1",
@@ -1569,6 +1570,17 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/eastasianwidth": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "react": "^18.3.1",
         "react-chartjs-2": "^5.2.0",
         "react-dom": "^18.3.1",
-        "react-transition-group": "^4.4.5"
+        "react-transition-group": "^4.4.5",
+        "yaml-loader": "^0.8.1"
       },
       "devDependencies": {
         "autoprefixer": "^10.4.20",
@@ -1114,6 +1115,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/big.js": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -1621,6 +1631,15 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/emojis-list": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.17.1",
@@ -3325,6 +3344,12 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/javascript-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/javascript-stringify/-/javascript-stringify-2.1.0.tgz",
+      "integrity": "sha512-JVAfqNPTvNq3sB/VHQJAFxN/sPgKnsKrCwyRt15zwNCdrMMJDdcEOdubuy+DuJYYdm0ox1J4uzEuYKkN+9yhVg==",
+      "license": "MIT"
+    },
     "node_modules/jiti": {
       "version": "1.21.6",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.6.tgz",
@@ -3464,6 +3489,32 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/loader-utils": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+      "license": "MIT",
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=8.9.0"
+      }
+    },
+    "node_modules/loader-utils/node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -5526,10 +5577,23 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.1.tgz",
       "integrity": "sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/yaml-loader": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/yaml-loader/-/yaml-loader-0.8.1.tgz",
+      "integrity": "sha512-BCEndnUoi3BaZmePkwGGe93txRxLgMhBa/gE725v1/GHnura8QvNs7c4+4C1yyhhKoj3Dg63M7IqhA++15j6ww==",
+      "license": "MIT",
+      "dependencies": {
+        "javascript-stringify": "^2.0.1",
+        "loader-utils": "^2.0.0",
+        "yaml": "^2.0.0"
       },
       "engines": {
         "node": ">= 14"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "react": "^18.3.1",
     "react-chartjs-2": "^5.2.0",
     "react-dom": "^18.3.1",
-    "react-transition-group": "^4.4.5"
+    "react-transition-group": "^4.4.5",
+    "yaml-loader": "^0.8.1"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.20",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "dotenv": "^16.4.5",
     "next": "^14.2.13",
     "primeflex": "^3.3.1",
     "primeicons": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -8,12 +8,14 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "chart.js": "^4.4.5",
     "dotenv": "^16.4.5",
     "next": "^14.2.13",
     "primeflex": "^3.3.1",
     "primeicons": "^6.0.1",
     "primereact": "^10.8.3",
     "react": "^18.3.1",
+    "react-chartjs-2": "^5.2.0",
     "react-dom": "^18.3.1",
     "react-transition-group": "^4.4.5"
   },

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "scripts": {
     "dev": "NODE_ENV=development next dev",
+    "win-dev": "next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/pages/BarChart.js
+++ b/pages/BarChart.js
@@ -9,7 +9,11 @@ const BarChart = ({ data }) => {
     datasets: [
       {
         label: 'Job Stats',
-        data: [data.runs, data.fails, data.skips],
+        data: [
+          data?.runs || 0, 
+          data?.fails || 0, 
+          data?.skips || 0
+        ],
         backgroundColor: ['#36a2eb', '#ff6384', '#ffcd56'],
         borderColor: ['#36a2eb', '#ff6384', '#ffcd56'],
         borderWidth: 1,

--- a/pages/BarChart.js
+++ b/pages/BarChart.js
@@ -1,0 +1,36 @@
+import { Bar } from 'react-chartjs-2';
+import { Chart as ChartJS, CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend } from 'chart.js';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
+
+const BarChart = ({ data }) => {
+  const chartData = {
+    labels: ['Runs', 'Fails', 'Skips'],
+    datasets: [
+      {
+        label: 'Job Stats',
+        data: [data.runs, data.fails, data.skips],
+        backgroundColor: ['#36a2eb', '#ff6384', '#ffcd56'],
+        borderColor: ['#36a2eb', '#ff6384', '#ffcd56'],
+        borderWidth: 1,
+        barThickness: 10
+      },
+    ],
+  };
+
+  const options = {
+    indexAxis: 'y', // Horizontal bar chart
+    scales: {
+      x: { beginAtZero: true },
+    },
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: { display: false },
+    },
+  };
+
+  return <Bar data={chartData} options={options} />;
+};
+
+export default BarChart;

--- a/pages/index.js
+++ b/pages/index.js
@@ -356,8 +356,8 @@ export default function Home() {
   return (
     <>
       <title>Kata CI Dashboard</title>
-      <div className="text-center text-xs md:text-base">
-        <h1 className={"text-4xl mt-4 mb-6 underline text-inherit \
+      <div className="xl:text-center text-xs md:text-base">
+        <h1 className={"text-4xl mt-4 ml-4 mb-6 underline text-inherit \
                         hover:text-blue-500"}>
           <a
             href={display === 'nightly' 
@@ -372,12 +372,12 @@ export default function Home() {
           </a>
         </h1>
 
-        <div className="xl:absolute l:flex mx-auto top-5 right-5 w-96 h-24">
+        <div className="absolute l:flex mx-auto top-5 right-5 w-96 h-24">
               <BarChart data={totalStats} />
         </div>
 
         <div className="flex flex-wrap mt-2 p-4 text-base">
-          <div className="space-x-2 pr-4 mx-auto mb-2 lg:ml-0">
+          <div className="pr-4 mb-2 space-x-2 mx-auto lg:ml-0">
             <button 
               className={tabClass(display === "nightly")}
               onClick={() => setDisplay("nightly")}>
@@ -390,8 +390,8 @@ export default function Home() {
             </button>
           </div>
 
-          <div className="flex flex-col lg:flex-row items-center lg:space-x-4 mx-auto lg:mr-0">
-            <form className="p-2 h-fit mb-2 bg-gray-700 border-2 border-gray-600 flex flex-row" onSubmit={(e) => handleForm(e)}> 
+          <div className="flex flex-col 2xl:flex-row items-center space-x-4 mx-auto xl:mr-0">
+            <form className="flex flex-row p-2 h-fit mb-2 bg-gray-700 border-2 border-gray-600" onSubmit={(e) => handleForm(e)}> 
               <div>
                 <select name="matchMode" className="px-1 h-fit rounded-lg">
                   <option value="or">Match Any</option>
@@ -403,7 +403,7 @@ export default function Home() {
               </div>
               <button type="submit" className="bg-blue-500 text-white px-4  rounded-3xl">Submit</button>
             </form>
-            <div className="flex mb-2 space-x2 flex-row lg:mr-0 lg:space-x-2">
+            <div className="flex flex-row mb-2 space-x-2 xl:mr-0">
               <button 
                 className={buttonClass()} 
                 onClick={() => clearSearch()}>

--- a/pages/index.js
+++ b/pages/index.js
@@ -377,7 +377,7 @@ export default function Home() {
         </div>
 
         <div className="flex flex-wrap mt-2 p-4 text-base">
-          <div className="space-x-2 pb-4 pr-4 mx-auto lg:ml-0">
+          <div className="space-x-2 pr-4 mx-auto lg:ml-0">
             <button 
               className={tabClass(display === "nightly")}
               onClick={() => setDisplay("nightly")}>
@@ -390,7 +390,19 @@ export default function Home() {
             </button>
           </div>
 
-          <div className="space-x-2 mx-auto lg:mr-0">
+          <div className="flex flex-col lg:flex-row items-center lg:space-x-4">
+            <form className="p-2 h-fit bg-gray-700 border-2 border-gray-600 flex flex-row" onSubmit={(e) => handleForm(e)}> 
+              <div>
+                <select name="matchMode" className="px-1 h-fit rounded-lg">
+                  <option value="or">Match Any</option>
+                  <option value="and">Match All</option>
+                </select>
+              </div>
+              <div className="mx-2">
+                <input type="text" name="value" required></input>
+              </div>
+              <button type="submit" className="bg-blue-500 text-white px-4  rounded-3xl">Submit</button>
+            </form>
             <button 
               className={buttonClass()} 
               onClick={() => clearSearch()}>
@@ -408,28 +420,8 @@ export default function Home() {
             </button>
           </div>
         </div>
-
-
-        <div className="flex flex-col items-center min-[960px]:mr-4 text-base">
-          <div className="flex min-[960px]:justify-end justify-center w-full"> 
-            <form className="p-2 bg-gray-700 rounded-md flex flex-row" onSubmit={(e) => handleForm(e)}> 
-              <div>
-                <label className="block text-white">Match Mode:</label>
-                <select name="matchMode" className="px-1 h-fit rounded-lg">
-                  <option value="or">Match Any</option>
-                  <option value="and">Match All</option>
-                </select>
-              </div>
-              <div className="mx-2">
-                <label className="block text-white">Search Text:</label>
-                <input type="text" name="value" required></input>
-              </div>
-              <button type="submit" className="bg-blue-500 text-white px-4 rounded-3xl">Submit</button>
-            </form>
-          </div>
-        </div>
         
-        <div className="mt-4 text-lg text-center">Total Rows: {rows.length}</div>
+        <div className="mt-1 text-lg text-center">Total Rows: {rows.length}</div>
 
         <main className={"m-0 h-full px-4 overflow-x-hidden overflow-y-auto \
                           bg-surface-ground antialiased select-text"}>

--- a/pages/index.js
+++ b/pages/index.js
@@ -50,13 +50,17 @@ export default function Home() {
   // Get bar chart statistics. 
   const getTotalStats = (data) => {
     return data.reduce((acc, job) => {
-      acc.runs += job.runs;
+      acc.runs  += job.runs;
       acc.fails += job.fails;
       acc.skips += job.skips;
       return acc;
     }, { runs: 0, fails: 0, skips: 0 });
   };
-  const totalStats = display === "nightly" ? getTotalStats(jobs) : getTotalStats(checks);
+
+  const totalStats = display === "nightly" 
+    ? getTotalStats(jobs) 
+    : getTotalStats(checks);
+
 
   // Clear search parameters if they exist.
   const clearSearch = () => {
@@ -66,10 +70,20 @@ export default function Home() {
     }
   }
 
+  const buttonClass = (active) => `tab px-4 py-2 border-2 
+    ${active ? "border-blue-500 bg-blue-500 text-white" 
+      : "border-gray-300 bg-white hover:bg-gray-100"}`;
+
+  const tabClass = (active) => `tab px-4 py-2 border-b-2 focus:outline-none
+    ${active ? "border-blue-500 bg-gray-300" 
+      : "border-gray-300 bg-white hover:bg-gray-100"}`;
+
+      
   const matchAll = (filteredJobs, parts) => {
     for (let i = 2; i < parts.length; i++) {
       const [matchMode, value] = parts[i].split("=")[1].split("&");
-      const decoded = decodeURIComponent(value).replace("/", "").trim().toLowerCase();
+      const decoded = decodeURIComponent(value)
+        .replace("/", "").trim().toLowerCase();
       const filterMap = {
         contains   : (name) => name.includes(decoded),
         notContains: (name) => !name.includes(decoded),
@@ -78,32 +92,37 @@ export default function Home() {
         startsWith : (name) => name.startsWith(decoded),
         endsWith   : (name) => name.endsWith(decoded),
       };
-      filteredJobs = filteredJobs.filter((job) => filterMap[matchMode](job.name.toLowerCase()));
+      filteredJobs = filteredJobs.filter((job) => 
+        filterMap[matchMode](job.name.toLowerCase()));
     }
     return filteredJobs;
   };
 
   const matchAny = (name, parts) => {
     const filterMap = {
-      contains   : (name) => name.includes(decoded),
-      notContains: (name) => !name.includes(decoded),
-      equals     : (name) => name === decoded,
-      notEquals  : (name) => name !== decoded,
-      startsWith : (name) => name.startsWith(decoded),
-      endsWith   : (name) => name.endsWith(decoded),
+      contains   : (name, decoded) => name.includes(decoded),
+      notContains: (name, decoded) => !name.includes(decoded),
+      equals     : (name, decoded) => name === decoded,
+      notEquals  : (name, decoded) => name !== decoded,
+      startsWith : (name, decoded) => name.startsWith(decoded),
+      endsWith   : (name, decoded) => name.endsWith(decoded),
     };
     return parts.slice(2).some(part => {
       const [matchMode, value] = part.split('=')[1].split('&');
-      const decoded = decodeURIComponent(value).replace('/', '').trim().toLowerCase();
+      const decoded = decodeURIComponent(value)
+        .replace('/', '').trim().toLowerCase();
       return filterMap[matchMode]?.(name, decoded);
     });
   };
   
   useEffect(() => {
     setLoading(true);
+    // Filter based on required tag.
     let filteredJobs = display === "nightly" ? jobs : checks;
-    if (requiredFilter) filteredJobs = filteredJobs.filter((job) => job.required);
-
+    if (requiredFilter){
+      filteredJobs = filteredJobs.filter((job) => job.required);
+    }
+    //Filter based on the URL. 
     const urlParts = window.location.href.split("?");
     if(urlParts[2] !== undefined){
       if (urlParts[1] === "and/"){
@@ -112,17 +131,16 @@ export default function Home() {
         filteredJobs =  filteredJobs.filter((job) =>
           matchAny(job.name.toLowerCase(), urlParts));
       }
-    }
-   
+    } 
     setRows(
       filteredJobs.map((job) => ({
-        name    : job.name,
-        runs    : job.runs,
-        fails   : job.fails,
-        skips   : job.skips,
-        required: job.required,
-        weather : getWeatherIndex(job),
-        reruns  : job.reruns,
+        name          : job.name,
+        runs          : job.runs,
+        fails         : job.fails,
+        skips         : job.skips,
+        required      : job.required,
+        weather       : getWeatherIndex(job),
+        reruns        : job.reruns,
         total_reruns  : job.reruns.reduce((total, r) => total + r, 0),
       }))
     );
@@ -137,7 +155,9 @@ export default function Home() {
 
 
   const getWeatherIndex = (stat) => {
-    const failRate = (stat.fails + stat.skips) / (stat.runs + stat.reruns.reduce((total, r) => total + r, 0));
+    const failRate = (stat.fails + stat.skips) / 
+                     (stat.runs + stat.reruns.reduce((total, r) =>
+                      total + r, 0));
     let idx = Math.floor((failRate * 10) / 2);
     if (idx === icons.length) idx -= 1;
     return isNaN(idx) ? 4 : idx;
@@ -145,7 +165,10 @@ export default function Home() {
 
   const weatherTemplate = (data) => (
     <div>
-      <Image src={`${basePath}/${icons[getWeatherIndex(data)]}`} alt="weather" width={32} height={32} />
+      <Image
+        src={`${basePath}/${icons[getWeatherIndex(data)]}`}
+        alt="weather" width={32}
+        height={32}/>
     </div>
   );
 
@@ -155,26 +178,26 @@ export default function Home() {
     </span>
   );
 
-  const buttonClass = (active) => `tab px-4 py-2 border-2 
-    ${active ? "border-blue-500 bg-blue-500 text-white" : "border-gray-300 bg-white"}`;
-
-  const tabClass = (active) => `tab px-4 py-2 border-b-2 focus:outline-none
-    ${active ? "border-blue-500 bg-gray-300" : "border-gray-300 bg-white"}`;
-
 
   const toggleRow = (rowData) => {
     setExpandedRows((prev) =>
-      prev.includes(rowData) ? prev.filter((r) => r !== rowData) : [...prev, rowData]
+      prev.includes(rowData) 
+        ? prev.filter((r) => r !== rowData) 
+        : [...prev, rowData]
     );
   };
-
   const overlayRefs = useRef([]);
 
   const rowExpansionTemplate = (data) => {
-    const job = (display === "nightly" ? jobs : checks).find((job) => job.name === data.name);
+    const job = (display === "nightly" 
+      ? jobs 
+      : checks).find((job) => job.name === data.name);
   
-    if (!job) return <div className="p-3 bg-gray-100">No data available for this job.</div>;
-  
+    if (!job) return (
+        <div className="p-3 bg-gray-100">
+          No data available for this job.
+        </div>); 
+
     const getRunStatusIcon = (runs) => {
       if (Array.isArray(runs)) {
         const allPass = runs.every(run => run === "Pass");
@@ -202,8 +225,18 @@ export default function Home() {
     return (
       <div key={`${job.name}-runs`} className="p-3 bg-gray-100">
         <div className="flex flex-wrap gap-4">
-          {runEntries.map(({run_num, result, url, reruns, rerun_result, attempt_urls }, idx) => {
-            const allResults = rerun_result ?  [result, ...rerun_result] : [result];
+          {runEntries.map(({
+            run_num, 
+            result, 
+            url, 
+            reruns, 
+            rerun_result, 
+            attempt_urls 
+          }, idx) => {
+            const allResults = rerun_result 
+              ?  [result, ...rerun_result] 
+              : [result];
+
             const runStatuses = allResults.map((result, idx) => 
               `${allResults.length - idx}. ${result === 'Pass' 
                 ? '✅ Success' 
@@ -211,30 +244,38 @@ export default function Home() {
                   ? '❌ Fail' 
                   : '⚠️ Warning'}`);
 
-            const sanitizedJobName = job.name.replace(/[^a-zA-Z0-9-_]/g, ''); // IDs can't have a '/'...
+            // IDs can't have a '/'...
+            const sanitizedJobName = job.name.replace(/[^a-zA-Z0-9-_]/g, '');
             const badgeId = `badge-tooltip-${sanitizedJobName}-${run_num}`;
-            overlayRefs.current[idx] = overlayRefs.current[idx] || React.createRef();
+            overlayRefs.current[badgeId] = overlayRefs.current[badgeId] 
+              || React.createRef();
 
             return (
               <div key={run_num} className="flex">
                 <div key={idx} className="flex items-center">
                   <a href={url} target="_blank" rel="noopener noreferrer">
+                  {/* <a href={attempt_urls[0]} target="_blank" rel="noopener noreferrer"> */}
                     {getRunStatusIcon(allResults)} {run_num}
                   </a>
                 </div>
                 {reruns > 0 &&(
                   <span className="p-overlay-badge">
-                    <sup  id={badgeId}
-                          className="text-xs font-bold align-super ml-1"
-                          onMouseEnter={(e) => overlayRefs.current[idx].current.toggle(e)}>
-                    {reruns}
+                    <sup  className="text-xs font-bold align-super ml-1"
+                          onMouseEnter={(e) => 
+                            overlayRefs.current[badgeId].current.toggle(e)}>
+                      {reruns}
                     </sup>
-                    <OverlayPanel ref={overlayRefs.current[idx]} dismissable>
+                    <OverlayPanel ref={overlayRefs.current[badgeId]} dismissable
+                    onMouseLeave={(e) => 
+                      overlayRefs.current[badgeId].current.toggle(e)}>
                     <ul className="bg-white border rounded shadow-lg p-2">
                       {runStatuses.map((status, index) => (
-                        <li key={index} className="py-1 px-2 hover:bg-gray-200">
-                          <a href={attempt_urls[index]} target="_blank" rel="noopener noreferrer">
-                            {status}
+                        <li className="p-2 hover:bg-gray-200">
+                          <a 
+                            href={attempt_urls[index]} 
+                            target="_blank" 
+                            rel="noopener noreferrer">
+                              {status}
                           </a>
                         </li>
                       ))}
@@ -275,7 +316,8 @@ export default function Home() {
       }
 
       e.constraints.constraints.forEach((c) => {
-        path += `/?search=${encodeURIComponent(c.matchMode)}&${encodeURIComponent(c.value.trim())}`;
+        path += `/?search=${encodeURIComponent(c.matchMode)}&` +
+                          `${encodeURIComponent(c.value.trim())}`;
       });
 
       window.location.href = `${basePath}${path}`;
@@ -297,28 +339,38 @@ export default function Home() {
         field="name"
         header="Name"
         body={nameTemplate}
+        className="select-all"
         filter
-        sortable
         onFilterApplyClick={(e) => handleFilterApply(e)}
         maxConstraints={4}
         filterHeader="Filter by Name"
         filterPlaceholder="Search..."
+        sortable
       />
-      <Column field = {"required"} header = "Required" sortable />
-      <Column field = {"runs"}   
-              header = "Runs"
-              className="whitespace-nowrap px-2"
-              // body={(data) => (
-              //   <span className="whitespace-nowrap">
-              //     <span className="font-bold">{data.runs + data.total_reruns}</span> 
-              //     {data.total_reruns > 0 ? ` (${data.total_reruns} reruns)` : ''}
-              //   </span>
-              // )}            
-              sortable />
-      <Column field = {"total_reruns"}  header = "Reruns"    sortable />
-      <Column field = {"fails"}  header = "Fails"    sortable />
-      <Column field = {"skips"}  header = "Skips"    sortable />
-      <Column field = "weather"  header = "Weather"  body = {weatherTemplate} sortable />
+      <Column field = {"required"}      header = "Required" sortable/>
+      <Column 
+        field = {"runs"}   
+        header = "Runs"
+        className="whitespace-nowrap px-2 select-all"
+        // body={(data) => (
+        //   <span className="whitespace-nowrap">
+        //     <span className="font-bold">
+        //         {data.runs + data.total_reruns}
+        //       </span> 
+        //     {data.total_reruns > 0 
+        //       ? ` (${data.total_reruns} reruns)` 
+        //       : ''}
+        //   </span>
+        // )}            
+        sortable />
+      <Column field = {"total_reruns"}  header = "Reruns"  sortable/>
+      <Column field = {"fails"}         header = "Fails"   sortable/>
+      <Column field = {"skips"}         header = "Skips"   sortable/>
+      <Column 
+        field = "weather"  
+        header = "Weather"  
+        body = {weatherTemplate} 
+        sortable />
     </DataTable>
   );
 
@@ -326,11 +378,14 @@ export default function Home() {
     <>
       <title>Kata CI Dashboard</title>
       <div className="text-center text-xs md:text-base">
-        <h1 className={"text-4xl mt-4 mb-6 underline text-inherit hover:text-blue-500"}>
+        <h1 className={"text-4xl mt-4 mb-6 underline text-inherit \
+                        hover:text-blue-500"}>
           <a
             href={display === 'nightly' 
-              ? "https://github.com/kata-containers/kata-containers/actions/workflows/ci-nightly.yaml"
-              : "https://github.com/kata-containers/kata-containers/actions/workflows/ci-on-push.yaml"}
+              ? "https://github.com/kata-containers/kata-containers/" +
+                "actions/workflows/ci-nightly.yaml"
+              : "https://github.com/kata-containers/kata-containers/" +
+                "actions/workflows/ci-on-push.yaml"}
             target="_blank"
             rel="noopener noreferrer"
           >
@@ -338,49 +393,47 @@ export default function Home() {
           </a>
         </h1>
 
-        
         <div className="xl:absolute l:flex mx-auto top-5 right-5 w-96 h-24">
               <BarChart data={totalStats} />
         </div>
 
         <div className="flex justify-between items-center mt-2 ml-4">
           <div className="tabs flex space-x-2">
-            <button className={tabClass(display === "nightly")}
-              onClick={() => setDisplay("nightly")}
-            >
-              Nightly Jobs
+            <button 
+              className={tabClass(display === "nightly")}
+              onClick={() => setDisplay("nightly")}>
+                Nightly Jobs
             </button>
-            <button className={tabClass(display === "prchecks")}
-              onClick={() => setDisplay("prchecks")}
-            >
-              PR Checks
+            <button 
+              className={tabClass(display === "prchecks")}
+              onClick={() => setDisplay("prchecks")}>
+                PR Checks
             </button>
           </div>
 
-          <div className={"m-0 h-full space-x-2 p-4 overflow-x-hidden overflow-y-auto \
-                          bg-surface-ground font-normal text-text-color antialiased select-text"}>
-            <button className={buttonClass()} 
+          <div className={"space-x-2 p-4 bg-surface-ground"}>
+            <button 
+              className={buttonClass()} 
               onClick={() => clearSearch()}>
-              Clear Search
+                Clear Search
             </button>
-
-            <button className={buttonClass(keepSearch)} 
+            <button 
+              className={buttonClass(keepSearch)} 
               onClick={() => setKeepSearch(!keepSearch)}>
-              Keep URL Search Terms
+                Keep URL Search Terms
             </button>
-
-            <button className={buttonClass(requiredFilter)} 
+            <button 
+              className={buttonClass(requiredFilter)} 
               onClick={() => setRequiredFilter(!requiredFilter)}>
-              Required Jobs Only
+                Required Jobs Only
             </button>
           </div>
-
         </div>
 
-        <main className={"m-0 h-full px-4 overflow-x-hidden overflow-y-auto bg-surface-ground \
-                          font-normal text-text-color antialiased select-text"}>
-          <div>{renderTable()}</div>
+        <main className={"m-0 h-full px-4 overflow-x-hidden overflow-y-auto \
+                          bg-surface-ground antialiased select-text"}>
           <div className="mt-4 text-lg">Total Rows: {rows.length}</div>
+          <div>{renderTable()}</div>
         </main>
       </div>
     </>

--- a/pages/index.js
+++ b/pages/index.js
@@ -165,15 +165,26 @@ export default function Home() {
                   )
                   .map((run, index) => (
                     <div key={index} style={{ display: "flex", alignItems: "center", marginRight: "1rem" }}>
-                      {display === "nightly" && (
+                      {/* {display === "nightly" && (
                         <p className="mr-1 font-bold">{run.attempts}</p> 
-                      )}
+                      )} */}
                       <a href={run.url} target="_blank">
                           {getRunStatusIcon(runs)} {run.run_num}
                       </a>
+                      {display === "nightly" && (
+                      <span className="p-overlay-badge" style={{ fontSize: '1rem' }}>
+                        <sup
+                          id={badgeId}
+                          style={{ fontSize: '0.7rem', verticalAlign: 'super', marginLeft: '0.3rem' }}
+                        >
+                          {run.attempts}
+                        </sup>
+                        <Tooltip target={`#${badgeId}`} content={runStatuses} position="top" />
+                      </span>
+                      )}
                   </div>
                 ))}
-                {count > 1 && (
+                {display === "prchecks" && (
                   <span className="p-overlay-badge" style={{ fontSize: '1rem' }}>
                     <sup
                       id={badgeId}

--- a/pages/index.js
+++ b/pages/index.js
@@ -524,7 +524,7 @@ export default function Home() {
     <>
 
       <title>Kata CI Dashboard</title>
-      <div className="xl:text-center text-xs md:text-base">
+      <div className="text-center text-xs md:text-base">
         <h1 className={"text-4xl mt-4 ml-4 mb-6 underline text-inherit \
                         hover:text-blue-500"}>
           <a
@@ -540,13 +540,13 @@ export default function Home() {
           </a>
         </h1>
 
-        <div className="absolute l:flex mx-auto top-5 right-5 w-96 h-24">
+        <div className="min-[1231px]:absolute flex mx-auto top-5 right-5 w-96 h-24">
               <BarChart data={totalStats} />
         </div>
 
 
-        <div className="flex flex-wrap mt-2 p-4 text-base">
-          <div className="space-x-2 pb-4 pr-4 mx-auto lg:ml-0 flex">
+        <div className="flex flex-wrap mt-2 p-4 md:text-base text-xs">
+          <div className="space-x-2 pb-2 pr-2 mx-auto xs:ml-0 flex">
             <button 
               className={tabClass(display === "nightly")}
               onClick={() => setDisplay("nightly")}>
@@ -560,10 +560,10 @@ export default function Home() {
             <button 
               className={tabClass(display === "prsingle")}
               onClick={() => setDisplay("prsingle")}>
-              Single PR View
+              Single PR
             </button>
             {display === "prsingle" && ( 
-              <div className="bg-blue-500 p-2 rounded-xl">
+              <div className="bg-blue-500 p-2 rounded-xl h-fit">
               <select 
                 id="selectedrun"
                 className="px-1 h-fit rounded-lg"
@@ -578,7 +578,7 @@ export default function Home() {
               )}
             </div>
 
-          <div className="space-x-2 mx-auto lg:mr-0">
+          <div className="space-x-2 mx-auto xs:mr-0">
             <button 
               className={buttonClass()} 
               onClick={() => clearSearch()}>
@@ -597,9 +597,8 @@ export default function Home() {
           </div>
         </div>
 
-
-        <div className="flex flex-col items-center min-[960px]:mr-4 text-base">
-          <div className="flex min-[960px]:justify-end justify-center w-full"> 
+        <div className="flex flex-col items-center md:text-base text-xs">
+          <div className="flex min-[1231px]:justify-end justify-center w-full"> 
             <form className="p-2 bg-gray-700 rounded-md flex flex-row" onSubmit={(e) => handleForm(e)}> 
               <div>
                 <label className="block text-white">Match Mode:</label>
@@ -617,7 +616,7 @@ export default function Home() {
           </div>
         </div>
         
-        <div className="mt-1 text-lg text-center">
+        <div className="mt-1 text-center md:text-lg text-base">
           Total Rows: {display === "prsingle" ? rowsSingle.length : display === "prchecks" ? rowsPR.length : rowsNightly.length}
         </div>
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -151,7 +151,7 @@ export default function Home() {
         <div style={{ display: "flex", flexWrap: "wrap", gap: "1rem" }}>
           {runEntries.map(([run_num, { runs, count }]) => {
             const runStatuses = runs
-              .map((run, idx) => `${run.result === 'Pass' ? '✅ Success' : run.result === 'Fail' ? '❌ Fail' : '⚠️ Warning'}`)
+              .map((run) => `${run.result === 'Pass' ? '✅ Success' : run.result === 'Fail' ? '❌ Fail' : '⚠️ Warning'}`)
               .join('\n');
             
             const sanitizedJobName = job.name.replace(/[^a-zA-Z0-9-_]/g, ''); // IDs can't have a '/'...

--- a/pages/index.js
+++ b/pages/index.js
@@ -56,6 +56,13 @@ export default function Home() {
   };
   const totalStats = display === "nightly" ? getTotalStats(jobs) : getTotalStats(checks);
 
+  const clearSearch = () => {
+    const urlParts = window.location.href.split("?");
+    if(urlParts[1] !== undefined){
+      window.location.href = urlParts[0];
+    }
+  }
+
   const matchAll = (filteredJobs, parts) => {
     for (let i = 2; i < parts.length; i++) {
       const [matchMode, value] = parts[i].split("=")[1].split("&");
@@ -97,7 +104,6 @@ export default function Home() {
     if (requiredFilter) filteredJobs = filteredJobs.filter((job) => job.required);
 
     const urlParts = window.location.href.split("?");
-    console.log("1: " + urlParts[1])
     
     if(urlParts[2] !== undefined){
       if (urlParts[1] === "and/"){
@@ -334,6 +340,11 @@ export default function Home() {
 
           <div className={"m-0 h-full space-x-2 p-4 overflow-x-hidden overflow-y-auto \
                           bg-surface-ground font-normal text-text-color antialiased select-text"}>
+            <button className={buttonClass()} 
+              onClick={() => clearSearch()}>
+              Clear Search
+            </button>
+
             <button className={buttonClass(keepSearch)} 
               onClick={() => setKeepSearch(!keepSearch)}>
               Keep URL Search Terms

--- a/pages/index.js
+++ b/pages/index.js
@@ -37,10 +37,10 @@ export default function Home() {
   // Fetch the data (either local or external)
   useEffect(() => {
     const fetchData = async () => {
-      let nightlyData = process.env.NODE_ENV === "development" ? NightlyData : await fetch(
+      const nightlyData = process.env.NODE_ENV === "development" ? NightlyData : await fetch(
         "https://raw.githubusercontent.com/a1icja/kata-dashboard-next/refs/heads/latest-dashboard-data/data/job_stats.json"
       ).then((res) => res.json());
-      let prData = process.env.NODE_ENV === "development" ? PRData : await fetch(
+      const prData = process.env.NODE_ENV === "development" ? PRData : await fetch(
         "https://raw.githubusercontent.com/a1icja/kata-dashboard-next/refs/heads/latest-dashboard-data/data/check_stats.json");
 
       const mapData = (data) => Object.keys(data).map((key) => ({ name: key, ...data[key] }));
@@ -66,6 +66,8 @@ export default function Home() {
     ? getTotalStats(jobs) 
     : getTotalStats(checks);
 
+
+  // Set the display (including PR num for single view).
   useEffect(() => {
     const initialDisplay = new URLSearchParams(window.location.search).get("display");
     if (initialDisplay) {
@@ -78,28 +80,6 @@ export default function Home() {
       setDisplay(initialDisplay);
     }
   }, []);
-  
-
-  // Clear the search parameters, but only if they exist.
-  const clearSearch = () => {
-    if(window.location.href.includes("matchMode")){
-      const path = new URLSearchParams();
-      path.append("display", display);
-      if (display === "prsingle" && selectedPR) {
-        path.append("pr", selectedPR);
-      }
-      window.location.assign(`${basePath}/?${path.toString()}`);
-    }
-  };
-  
-
-  const buttonClass = (active) => `tab md:px-4 px-2 py-2 border-2 
-    ${active ? "border-blue-500 bg-blue-500 text-white" 
-      : "border-gray-300 bg-white hover:bg-gray-100"}`;
-
-  const tabClass = (active) => `tab md:px-4 px-2 py-2 border-b-2 focus:outline-none
-    ${active ? "border-blue-500 bg-gray-300" 
-      : "border-gray-300 bg-white hover:bg-gray-100"}`;
 
 
   // Filters the jobs s.t. all values must be contained in the name.
@@ -125,6 +105,7 @@ export default function Home() {
         });
     });
   };
+
 
   // Filter and set the rows for Nightly view. 
   useEffect(() => {
@@ -157,7 +138,6 @@ export default function Home() {
     );
     setLoading(false);
   }, [jobs, requiredFilter]);
-
 
   // Filter and set the rows for PR Checks view. 
   useEffect(() => {
@@ -217,7 +197,7 @@ export default function Home() {
             name: check.name,
             required: check.required,
             result: check.results[index],
-            reruns: check.reruns[index],
+            runs: check.reruns[index] + 1,
           }
         : null;
     }).filter(Boolean); 
@@ -225,6 +205,7 @@ export default function Home() {
     setRowsSingle(filteredData);
     setLoading(false);
   }, [checks, requiredFilter, selectedPR]);
+
 
   // Close all rows on view switch. 
   // Needed because if view is switched, breaks expanded row toggling.
@@ -251,12 +232,21 @@ export default function Home() {
     </div>
   );
 
+  
+  const buttonClass = (active) => `tab md:px-4 px-2 py-2 border-2 
+    ${active ? "border-blue-500 bg-blue-500 text-white" 
+      : "border-gray-300 bg-white hover:bg-gray-100"}`;
+
+  const tabClass = (active) => `tab md:px-4 px-2 py-2 border-b-2 focus:outline-none
+    ${active ? "border-blue-500 bg-gray-300" 
+      : "border-gray-300 bg-white hover:bg-gray-100"}`;
+
+
   const nameTemplate = (rowData) => (
     <div className="cursor-pointer" onClick={() => toggleRow(rowData)}>
     <span style={{ userSelect: 'text' }}>{rowData.name}</span>
   </div>
   );
-
 
   const toggleRow = (rowData) => {
     setExpandedRows((prev) =>
@@ -544,8 +534,8 @@ export default function Home() {
         sortable
       />
       <Column
-        field="reruns"
-        header="Reruns"
+        field="runs"
+        header="Total Runs"
         sortable
       />
     </DataTable>

--- a/pages/index.js
+++ b/pages/index.js
@@ -436,12 +436,14 @@ export default function Home() {
     if (view === "prsingle" && pr) {
       path.append("pr", pr);
     }
-    const urlParams = new URLSearchParams(window.location.search);
-    path.append("matchMode", urlParams.get("matchMode"));
+    if(window.location.href.includes("matchMode")){
+      const urlParams = new URLSearchParams(window.location.search);
+      path.append("matchMode", urlParams.get("matchMode"));
 
-    urlParams.getAll("value").forEach((val) => {
-      path.append("value", val); 
-    });
+      urlParams.getAll("value").forEach((val) => {
+        path.append("value", val); 
+      });
+    }
     // Update the URL without reloading
     window.history.pushState({}, '', `${basePath}/?${path.toString()}`);
   };

--- a/pages/index.js
+++ b/pages/index.js
@@ -600,9 +600,11 @@ export default function Home() {
           </a>
         </h1>
 
+        {display !== "prsingle" && ( 
         <div className="min-[1231px]:absolute flex mx-auto top-5 right-5 w-96 h-24">
               <BarChart data={totalStats} />
         </div>
+        )}
 
 
         <div className="flex flex-wrap mt-2 p-4 md:text-base text-xs">
@@ -641,9 +643,9 @@ export default function Home() {
                     updateUrl("prsingle", e.target.value);
                   }}
                 value={selectedPR} >
-                  <option value="" disabled>Select PR</option>
+                  <option value="">Select PR</option>
                   {runNumOptions.map(num => (
-                    <option key={num} value={num}>{num}</option>
+                    <option key={num} value={num}>#{num}</option>
                   ))}
               </select>
               </div>

--- a/pages/index.js
+++ b/pages/index.js
@@ -198,24 +198,30 @@ export default function Home() {
     return (
       <div key={`${job.name}-runs`} className="p-3 bg-gray-100">
         <div className="flex flex-wrap gap-4">
-          {runEntries.map(({run_num, result, reruns, rerun_result, url }, idx) => {
-            const runStatuses = rerun_result
-              ? rerun_result.map((result) => `${result === 'Pass' ? '✅ Success' : result === 'Fail' ? '❌ Fail' : '⚠️ Warning'}`)
-              .join('\n')
-              : '';
-            
+          {runEntries.map(({run_num, result, url, reruns, rerun_result, rerun_urls }, idx) => {
+            //var runStatuses = `${result === 'Pass' ? '✅ Success' : result === 'Fail' ? '❌ Fail' : '⚠️ Warning'}`;
+
+            const allResults = rerun_result ?  [result, ...rerun_result] : [result];
+            const runStatuses = allResults.map((result, idx) => 
+              `${allResults.length - idx}. ${result === 'Pass' 
+                ? '✅ Success' 
+                : result === 'Fail' 
+                  ? '❌ Fail' 
+                  : '⚠️ Warning'}`).join('\n');
+
+            // console.log("runStatuses: " +runStatuses);
+
             const sanitizedJobName = job.name.replace(/[^a-zA-Z0-9-_]/g, ''); // IDs can't have a '/'...
             const badgeId = `badge-tooltip-${sanitizedJobName}-${run_num}`;
             return (
               <div key={run_num} className="flex">
                 <div key={idx} className="flex items-center">
                   <a href={url} target="_blank">
-                    {reruns > 1 
-                      ? getRunStatusIcon(rerun_result) 
-                      : getRunStatusIcon(result)} {run_num}
+                    {getRunStatusIcon(allResults)} {run_num}
+                      {/* {result === 'Pass' ? '✅' : result === 'Fail' ? '❌' : '⚠️'} {run_num} */}
                   </a>
                 </div>
-                {reruns > 1 &&(
+                {reruns > 0 &&(
                   <span className="p-overlay-badge">
                     <sup  id={badgeId}
                           className="text-xs font-bold align-super ml-1">

--- a/pages/index.js
+++ b/pages/index.js
@@ -153,7 +153,7 @@ export default function Home() {
         <div style={{ display: "flex", flexWrap: "wrap", gap: "1rem" }}>
           {runEntries.map(([run_num, { runs, count }]) => {
             const runStatuses = runs
-              .map((run, idx) => `${idx + 1}: ${run.result === 'Pass' ? '✅ Success' : run.result === 'Fail' ? '❌ Fail' : '⚠️ Warning'}`)
+              .map((run, idx) => `${run.result === 'Pass' ? '✅ Success' : run.result === 'Fail' ? '❌ Fail' : '⚠️ Warning'}`)
               .join('\n');
             
             const sanitizedJobName = job.name.replace(/[^a-zA-Z0-9-_]/g, ''); // IDs can't have a '/'...
@@ -247,8 +247,9 @@ export default function Home() {
         </a>
       </h1>
 
-      <div className="flex justify-center mt-4 ml-4">
-        <div className="tabs mr-10">
+      <div className="flex justify-between items-center mt-2 ml-4">
+
+        <div className="tabs flex space-x-2">
           <button
             className={`tab px-4 py-2 border-b-2 ${
               display === "nightly" ? "border-blue-500 bg-gray-300" : "border-gray-300 bg-white"
@@ -267,26 +268,28 @@ export default function Home() {
           </button>
         </div>
 
-        <button
-          className={`tab px-4 py-2 border-b-2 ${
-            keepSearch ? "border-blue-500 bg-gray-300" : "border-gray-300 bg-white"
-          } focus:outline-none`}
-          onClick={() => setKeepSearch(!keepSearch)}
-        >
-          Keep URL Search Terms
-        </button>
+        <div className={"m-0 h-full space-x-2 p-4 overflow-x-hidden overflow-y-auto \
+                         bg-surface-ground font-normal text-text-color antialiased select-text"}>
+          <button
+            className={`tab px-4 py-2 border-2 ${keepSearch ? "border-blue-500 bg-blue-500 text-white" : "border-gray-300 bg-white"}`}
+            onClick={() => setKeepSearch(!keepSearch)}
+            style={{ borderRadius: '0.25rem', transition: 'background-color 0.2s' }}
+          >
+            Keep URL Search Terms
+          </button>
+          <button
+            className={`tab px-4 py-2 border-2 ${requiredFilter ? "border-blue-500 bg-blue-500 text-white" : "border-gray-300 bg-white"}`}
+            onClick={() => setRequiredFilter(!requiredFilter)}
+            style={{ borderRadius: '0.25rem', transition: 'background-color 0.2s' }}
+          >
+            Required Jobs Only
+          </button>
+        </div>
 
-        <button
-          className={`tab px-4 py-2 border-b-2 ${requiredFilter 
-            ? "border-blue-500 bg-gray-300" 
-            : "border-gray-300 bg-white"}`}
-          onClick={() => setRequiredFilter(!requiredFilter)}
-        >
-          Required Jobs Only
-        </button>
       </div>
 
-      <main className={"m-0 h-full p-4 overflow-x-hidden overflow-y-auto bg-surface-ground font-normal text-text-color antialiased select-text"}>
+      <main className={"m-0 h-full px-4 overflow-x-hidden overflow-y-auto bg-surface-ground \
+                        font-normal text-text-color antialiased select-text"}>
         <div>{renderTable()}</div>
         <div className="mt-4 text-lg">Total Rows: {rows.length}</div>
       </main>

--- a/pages/index.js
+++ b/pages/index.js
@@ -82,6 +82,11 @@ export default function Home() {
     setLoading(false);
   }, [jobs, checks, requiredFilter, display]);
 
+  useEffect(() => {
+    setExpandedRows([])
+  }, [display]); 
+
+
   const getWeatherIndex = (stat) => {
     const failRate = (stat.fails + stat.skips) / stat.runs;
     let idx = Math.floor((failRate * 10) / 2);
@@ -179,7 +184,7 @@ export default function Home() {
                         >
                           {run.attempts}
                         </sup>
-                        <Tooltip target={`#${badgeId}`} content={runStatuses} position="top" />
+                        {/* <Tooltip target={`#${badgeId}`} content={runStatuses} position="top" /> */}
                       </span>
                       )}
                   </div>

--- a/pages/index.js
+++ b/pages/index.js
@@ -298,7 +298,7 @@ export default function Home() {
           {runEntries.map(({
             run_num, 
             result, 
-            // url, 
+            url, 
             reruns, 
             rerun_result, 
             attempt_urls 
@@ -342,7 +342,7 @@ export default function Home() {
                       {runStatuses.map((status, index) => (
                         <li key={index} className="p-2 hover:bg-gray-200">
                           <a 
-                            href={attempt_urls[index]} 
+                            href={attempt_urls[index] || `${url}/attempts/${index}`} 
                             target="_blank" 
                             rel="noopener noreferrer">
                               {status}

--- a/pages/index.js
+++ b/pages/index.js
@@ -82,7 +82,7 @@ export default function Home() {
 
   // Clear the search parameters, but only if they exist.
   const clearSearch = () => {
-    if(window.location.href.includes("?")){
+    if(window.location.href.includes("matchMode")){
       const path = new URLSearchParams();
       path.append("display", display);
       if (display === "prsingle" && selectedPR) {
@@ -381,7 +381,7 @@ export default function Home() {
   };
 
   // Apply search terms to the URL and reload the page. 
-  const handleForm = (e) => {
+  const handleSearch= (e) => {
     // Prevent the default behavior so that we can keep search terms.
     e.preventDefault();
     const matchMode = e.target.matchMode.value;
@@ -406,6 +406,19 @@ export default function Home() {
       window.location.assign(`${basePath}/?${path.toString()}`);
     }
   };
+
+  // Update the URL on display change
+  const updateUrl = (view, pr) => {
+    const path = new URLSearchParams();
+    path.append("display", view);
+    // Add PR number Single PR view and a PR is provided
+    if (view === "prsingle" && pr) {
+      path.append("pr", pr);
+    }
+    // Update the URL without reloading
+    window.history.pushState({}, '', `${basePath}/?${path.toString()}`);
+  };
+  
 
   // Render table for nightly view.
   const renderNightlyTable = () => (
@@ -567,17 +580,26 @@ export default function Home() {
           <div className="space-x-2 pb-2 pr-3 mx-auto flex">
             <button 
               className={tabClass(display === "nightly")}
-              onClick={() => setDisplay("nightly")}>
+              onClick={() => {
+                setDisplay("nightly");
+                updateUrl("nightly");
+              }}>
               Nightly Jobs
             </button>
             <button 
               className={tabClass(display === "prchecks")}
-              onClick={() => setDisplay("prchecks")}>
+              onClick={() => {
+                setDisplay("prchecks");
+                updateUrl("prchecks");
+              }}>
               PR Checks
             </button>
             <button 
               className={tabClass(display === "prsingle")}
-              onClick={() => setDisplay("prsingle")}>
+              onClick={() => {
+                setDisplay("prsingle");
+                updateUrl("prsingle", selectedPR);
+              }}>
               Single PR
             </button>
             {display === "prsingle" && ( 
@@ -585,7 +607,10 @@ export default function Home() {
               <select 
                 id="selectedrun"
                 className="px-1 h-fit rounded-lg"
-                onChange={(e) => setSelectedPR(e.target.value)}
+                onChange={(e) => {
+                    setSelectedPR(e.target.value);
+                    updateUrl("prsingle", e.target.value);
+                  }}
                 value={selectedPR} >
                   <option value="" disabled>Select PR</option>
                   {runNumOptions.map(num => (
@@ -617,7 +642,7 @@ export default function Home() {
 
         <div className="flex flex-col items-center md:text-base text-xs">
           <div className="flex min-[1126px]:justify-end justify-center w-full"> 
-            <form className="p-2 bg-gray-700 rounded-md flex flex-row" onSubmit={(e) => handleForm(e)}> 
+            <form className="p-2 bg-gray-700 rounded-md flex flex-row" onSubmit={(e) => handleSearch(e)}> 
               <div>
                 <label className="block text-white">Match Mode:</label>
                 <select name="matchMode" className="px-1 h-fit rounded-lg">

--- a/pages/index.js
+++ b/pages/index.js
@@ -416,6 +416,18 @@ export default function Home() {
     }
   };
 
+  // Clear the search parameters, but only if they exist.
+  const clearSearch = () => {
+    if(window.location.href.includes("matchMode")){
+      const path = new URLSearchParams();
+      path.append("display", display);
+      if (display === "prsingle" && selectedPR) {
+        path.append("pr", selectedPR);
+      }
+      window.location.assign(`${basePath}/?${path.toString()}`);
+    }
+  };
+
   // Update the URL on display change
   const updateUrl = (view, pr) => {
     const path = new URLSearchParams();
@@ -424,6 +436,12 @@ export default function Home() {
     if (view === "prsingle" && pr) {
       path.append("pr", pr);
     }
+    const urlParams = new URLSearchParams(window.location.search);
+    path.append("matchMode", urlParams.get("matchMode"));
+
+    urlParams.getAll("value").forEach((val) => {
+      path.append("value", val); 
+    });
     // Update the URL without reloading
     window.history.pushState({}, '', `${basePath}/?${path.toString()}`);
   };

--- a/pages/index.js
+++ b/pages/index.js
@@ -77,6 +77,7 @@ export default function Home() {
         skips   : job.skips,
         required: job.required,
         weather : getWeatherIndex(job),
+        reruns  : job.reruns,
       }))
     );
     setLoading(false);
@@ -237,10 +238,11 @@ export default function Home() {
         filterHeader="Filter by Name"
         filterPlaceholder="Search..."
       />
-      <Column field = "required" header = "Required" sortable />
+      <Column field = {"required"} header = "Required" sortable />
       <Column field = {"runs"}   header = "Runs"     sortable />
       <Column field = {"fails"}  header = "Fails"    sortable />
       <Column field = {"skips"}  header = "Skips"    sortable />
+      <Column field = {"reruns"}  header = "Reruns"    sortable />
       <Column field = "weather"  header = "Weather"  body = {weatherTemplate} sortable />
     </DataTable>
   );

--- a/pages/index.js
+++ b/pages/index.js
@@ -8,6 +8,7 @@ import { Tooltip }   from 'primereact/tooltip';
 import NightlyData  from "../data/job_stats.json";
 import PRData       from "../data/check_stats.json";
 import { basePath } from "../next.config.js";
+import BarChart from './BarChart'; 
 
 
 export default function Home() {
@@ -43,6 +44,17 @@ export default function Home() {
     };
     fetchData();
   }, []);
+
+  const getTotalStats = (data) => {
+    return data.reduce((acc, job) => {
+      acc.runs += job.runs;
+      acc.fails += job.fails;
+      acc.skips += job.skips;
+      return acc;
+    }, { runs: 0, fails: 0, skips: 0 });
+  };
+
+  const totalStats = display === "nightly" ? getTotalStats(jobs) : getTotalStats(checks);
 
   const applyFilter = (filteredJobs, parts) => {
     for (let i = 2; i < parts.length; i++) {
@@ -169,7 +181,8 @@ export default function Home() {
                     self.findIndex(r => r.run_num === run.run_num) === index // Skip duplicates
                   )
                   .map((run, index) => (
-                    <div key={index} style={{ display: "flex", alignItems: "center", marginRight: "1rem" }}>
+                    <div key={index} style={{ display: "flex", alignItems: "center" }}>
+
                       <a href={run.url} target="_blank">
                           {getRunStatusIcon(runs)} {run.run_num}
                       </a>
@@ -189,6 +202,15 @@ export default function Home() {
               </div>
             );
           })}
+        </div>
+        <div>
+          <br/>Maintainer: <a 
+            href="https://github.com/sprt"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-500 underline">
+              Aurelien Bombo
+          </a>
         </div>
       </div>
     );
@@ -251,7 +273,7 @@ export default function Home() {
     <>
       <title>Kata CI Dashboard</title>
       <div className="text-center">
-        <h1 className={"text-4xl mt-4 mb-0 underline text-inherit hover:text-blue-500"}>
+        <h1 className={"text-4xl mt-4 mb-6 underline text-inherit hover:text-blue-500"}>
           <a
             href={display === 'nightly' 
               ? "https://github.com/kata-containers/kata-containers/actions/workflows/ci-nightly.yaml"
@@ -276,6 +298,10 @@ export default function Home() {
             >
               PR Checks
             </button>
+          </div>
+
+          <div style={{ position: 'absolute', top: '20px', right: '20px', width: '450px', height: '100px' }}>
+            <BarChart data={totalStats} />
           </div>
 
           <div className={"m-0 h-full space-x-2 p-4 overflow-x-hidden overflow-y-auto \

--- a/pages/index.js
+++ b/pages/index.js
@@ -82,8 +82,6 @@ export default function Home() {
     setLoading(false);
   }, [jobs, checks, requiredFilter, display]);
 
-  useEffect(() => setExpandedRows([]), [display]);
-
   const getWeatherIndex = (stat) => {
     const failRate = (stat.fails + stat.skips) / stat.runs;
     let idx = Math.floor((failRate * 10) / 2);
@@ -109,16 +107,16 @@ export default function Home() {
     </span>
   );
 
+  const buttonClass = (active) => `tab px-4 py-2 border-2 
+    ${active ? "border-blue-500 bg-blue-500 text-white" : "border-gray-300 bg-white"}`;
+
+  const tabClass = (active) => `tab px-4 py-2 border-b-2 focus:outline-none
+    ${active ? "border-blue-500 bg-gray-300" : "border-gray-300 bg-white"}`;
+
   const rowExpansionTemplate = (data) => {
     const job = (display === "nightly" ? jobs : checks).find((job) => job.name === data.name);
   
-    if (!job) {
-      return (
-        <div className="p-3 bg-gray-100" style={{ marginLeft: "4.5rem", marginTop: "-2.0rem" }}>
-          <p>No data available for this job.</p>
-        </div>
-      );
-    }
+    if (!job) return <div className="p-3 bg-gray-100">No data available for this job.</div>;
 
     // Aggregate runs by run_num
     const aggregatedRuns = job.run_nums.reduce((acc, run_num, idx) => {
@@ -161,7 +159,7 @@ export default function Home() {
     
             return (
               <div key={run_num} style={{ display: "flex" }}>
-                <a href={runs[0].url}>
+                <a href={runs[0].url} target="_blank">
                   {getRunStatusIcon(runs)} {run_num}
                 </a>
                 {count > 1 && (
@@ -239,7 +237,9 @@ export default function Home() {
     <div className="text-center">
       <h1 className={"text-4xl mt-4 mb-0 underline text-inherit hover:text-blue-500"}>
         <a
-          href={"https://github.com/kata-containers/kata-containers/actions/workflows/ci-nightly.yaml"}
+          href={display === 'nightly' 
+            ? "https://github.com/kata-containers/kata-containers/actions/workflows/ci-nightly.yaml"
+            : "https://github.com/kata-containers/kata-containers/actions/workflows/ci-on-push.yaml"}
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -250,18 +250,12 @@ export default function Home() {
       <div className="flex justify-between items-center mt-2 ml-4">
 
         <div className="tabs flex space-x-2">
-          <button
-            className={`tab px-4 py-2 border-b-2 ${
-              display === "nightly" ? "border-blue-500 bg-gray-300" : "border-gray-300 bg-white"
-            } focus:outline-none`}
+          <button className={tabClass(display === "nightly")}
             onClick={() => setDisplay("nightly")}
           >
             Nightly Jobs
           </button>
-          <button
-            className={`tab px-4 py-2 border-b-2 ${
-              display === "prchecks" ? "border-blue-500 bg-gray-300" : "border-gray-300 bg-white"
-            } focus:outline-none`}
+          <button className={tabClass(display === "prchecks")}
             onClick={() => setDisplay("prchecks")}
           >
             PR Checks
@@ -270,18 +264,13 @@ export default function Home() {
 
         <div className={"m-0 h-full space-x-2 p-4 overflow-x-hidden overflow-y-auto \
                          bg-surface-ground font-normal text-text-color antialiased select-text"}>
-          <button
-            className={`tab px-4 py-2 border-2 ${keepSearch ? "border-blue-500 bg-blue-500 text-white" : "border-gray-300 bg-white"}`}
-            onClick={() => setKeepSearch(!keepSearch)}
-            style={{ borderRadius: '0.25rem', transition: 'background-color 0.2s' }}
-          >
+          <button className={buttonClass(keepSearch)} 
+            onClick={() => setKeepSearch(!keepSearch)}>
             Keep URL Search Terms
           </button>
-          <button
-            className={`tab px-4 py-2 border-2 ${requiredFilter ? "border-blue-500 bg-blue-500 text-white" : "border-gray-300 bg-white"}`}
-            onClick={() => setRequiredFilter(!requiredFilter)}
-            style={{ borderRadius: '0.25rem', transition: 'background-color 0.2s' }}
-          >
+
+          <button className={buttonClass(requiredFilter)} 
+            onClick={() => setRequiredFilter(!requiredFilter)}>
             Required Jobs Only
           </button>
         </div>

--- a/pages/index.js
+++ b/pages/index.js
@@ -159,8 +159,12 @@ export default function Home() {
             const badgeId = `badge-tooltip-${sanitizedJobName}-${run_num}`;
             return (
               <div key={run_num} style={{ display: "flex" }}>
-                {runs.map((run, index) => (
-                  <div key={index} style={{ display: "flex", alignItems: "center", marginRight: "1rem" }}>
+                {runs
+                  .filter((run, index, self) => 
+                    self.findIndex(r => r.run_num === run.run_num) === index // Skip duplicates
+                  )
+                  .map((run, index) => (
+                    <div key={index} style={{ display: "flex", alignItems: "center", marginRight: "1rem" }}>
                       {display === "nightly" && (
                         <p className="mr-1 font-bold">{run.attempts}</p> 
                       )}

--- a/pages/index.js
+++ b/pages/index.js
@@ -541,7 +541,7 @@ export default function Home() {
   );
 
   // Make a list of all unique run numbers in the check data.
-  const runNumOptions = [...new Set(checks.flatMap(check => check.run_nums))];
+  const runNumOptions = [...new Set(checks.flatMap(check => check.run_nums))].sort((a, b) => b - a);
     
   // Render table for prsingle view 
   const renderSingleViewTable = () => (

--- a/pages/index.js
+++ b/pages/index.js
@@ -253,8 +253,8 @@ export default function Home() {
             return (
               <div key={run_num} className="flex">
                 <div key={idx} className="flex items-center">
-                  <a href={url} target="_blank" rel="noopener noreferrer">
-                  {/* <a href={attempt_urls[0]} target="_blank" rel="noopener noreferrer"> */}
+                  {/* <a href={url} target="_blank" rel="noopener noreferrer"> */}
+                  <a href={attempt_urls[0]} target="_blank" rel="noopener noreferrer">
                     {getRunStatusIcon(allResults)} {run_num}
                   </a>
                 </div>
@@ -263,7 +263,7 @@ export default function Home() {
                     <sup  className="text-xs font-bold align-super ml-1"
                           onMouseEnter={(e) => 
                             overlayRefs.current[badgeId].current.toggle(e)}>
-                      {reruns}
+                      {reruns+1}
                     </sup>
                     <OverlayPanel ref={overlayRefs.current[badgeId]} dismissable
                     onMouseLeave={(e) => 
@@ -347,25 +347,25 @@ export default function Home() {
         filterPlaceholder="Search..."
         sortable
       />
-      <Column field = {"required"}      header = "Required" sortable/>
+      <Column field = "required"      header = "Required" sortable/>
       <Column 
-        field = {"runs"}   
+        field = "runs"   
         header = "Runs"
         className="whitespace-nowrap px-2 select-all"
         // body={(data) => (
         //   <span className="whitespace-nowrap">
         //     <span className="font-bold">
-        //         {data.runs + data.total_reruns}
-        //       </span> 
+        //       {data.runs}
+        //     </span > 
         //     {data.total_reruns > 0 
-        //       ? ` (${data.total_reruns} reruns)` 
+        //       ? ` (${data.runs + data.total_reruns} total)` 
         //       : ''}
         //   </span>
-        // )}            
+        // )} 
         sortable />
-      <Column field = {"total_reruns"}  header = "Reruns"  sortable/>
-      <Column field = {"fails"}         header = "Fails"   sortable/>
-      <Column field = {"skips"}         header = "Skips"   sortable/>
+      <Column field = "total_reruns"  header = "Reruns"  sortable/>
+      <Column field = "fails"         header = "Fails"   sortable/>
+      <Column field = "skips"         header = "Skips"   sortable/>
       <Column 
         field = "weather"  
         header = "Weather"  

--- a/pages/index.js
+++ b/pages/index.js
@@ -124,6 +124,7 @@ export default function Home() {
         run_num,
         result: job.results[idx],
         url: job.urls[idx],
+        attempts: display === "nightly" ? job.run_attempt[idx] : undefined,
       };
   
       if (!acc[run_num]) {
@@ -156,12 +157,18 @@ export default function Home() {
             
             const sanitizedJobName = job.name.replace(/[^a-zA-Z0-9-_]/g, ''); // IDs can't have a '/'...
             const badgeId = `badge-tooltip-${sanitizedJobName}-${run_num}`;
-    
             return (
               <div key={run_num} style={{ display: "flex" }}>
-                <a href={runs[0].url} target="_blank">
-                  {getRunStatusIcon(runs)} {run_num}
-                </a>
+                {runs.map((run, index) => (
+                  <div key={index} style={{ display: "flex", alignItems: "center", marginRight: "1rem" }}>
+                      {display === "nightly" && (
+                        <p className="mr-1 font-bold">{run.attempts}</p> 
+                      )}
+                      <a href={run.url} target="_blank">
+                          {getRunStatusIcon(runs)} {run.run_num}
+                      </a>
+                  </div>
+                ))}
                 {count > 1 && (
                   <span className="p-overlay-badge" style={{ fontSize: '1rem' }}>
                     <sup
@@ -234,54 +241,57 @@ export default function Home() {
   );
 
   return (
-    <div className="text-center">
-      <h1 className={"text-4xl mt-4 mb-0 underline text-inherit hover:text-blue-500"}>
-        <a
-          href={display === 'nightly' 
-            ? "https://github.com/kata-containers/kata-containers/actions/workflows/ci-nightly.yaml"
-            : "https://github.com/kata-containers/kata-containers/actions/workflows/ci-on-push.yaml"}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Kata CI Dashboard
-        </a>
-      </h1>
-
-      <div className="flex justify-between items-center mt-2 ml-4">
-
-        <div className="tabs flex space-x-2">
-          <button className={tabClass(display === "nightly")}
-            onClick={() => setDisplay("nightly")}
+    <>
+      <title>Kata CI Dashboard</title>
+      <div className="text-center">
+        <h1 className={"text-4xl mt-4 mb-0 underline text-inherit hover:text-blue-500"}>
+          <a
+            href={display === 'nightly' 
+              ? "https://github.com/kata-containers/kata-containers/actions/workflows/ci-nightly.yaml"
+              : "https://github.com/kata-containers/kata-containers/actions/workflows/ci-on-push.yaml"}
+            target="_blank"
+            rel="noopener noreferrer"
           >
-            Nightly Jobs
-          </button>
-          <button className={tabClass(display === "prchecks")}
-            onClick={() => setDisplay("prchecks")}
-          >
-            PR Checks
-          </button>
+            Kata CI Dashboard
+          </a>
+        </h1>
+
+        <div className="flex justify-between items-center mt-2 ml-4">
+
+          <div className="tabs flex space-x-2">
+            <button className={tabClass(display === "nightly")}
+              onClick={() => setDisplay("nightly")}
+            >
+              Nightly Jobs
+            </button>
+            <button className={tabClass(display === "prchecks")}
+              onClick={() => setDisplay("prchecks")}
+            >
+              PR Checks
+            </button>
+          </div>
+
+          <div className={"m-0 h-full space-x-2 p-4 overflow-x-hidden overflow-y-auto \
+                          bg-surface-ground font-normal text-text-color antialiased select-text"}>
+            <button className={buttonClass(keepSearch)} 
+              onClick={() => setKeepSearch(!keepSearch)}>
+              Keep URL Search Terms
+            </button>
+
+            <button className={buttonClass(requiredFilter)} 
+              onClick={() => setRequiredFilter(!requiredFilter)}>
+              Required Jobs Only
+            </button>
+          </div>
+
         </div>
 
-        <div className={"m-0 h-full space-x-2 p-4 overflow-x-hidden overflow-y-auto \
-                         bg-surface-ground font-normal text-text-color antialiased select-text"}>
-          <button className={buttonClass(keepSearch)} 
-            onClick={() => setKeepSearch(!keepSearch)}>
-            Keep URL Search Terms
-          </button>
-
-          <button className={buttonClass(requiredFilter)} 
-            onClick={() => setRequiredFilter(!requiredFilter)}>
-            Required Jobs Only
-          </button>
-        </div>
-
+        <main className={"m-0 h-full px-4 overflow-x-hidden overflow-y-auto bg-surface-ground \
+                          font-normal text-text-color antialiased select-text"}>
+          <div>{renderTable()}</div>
+          <div className="mt-4 text-lg">Total Rows: {rows.length}</div>
+        </main>
       </div>
-
-      <main className={"m-0 h-full px-4 overflow-x-hidden overflow-y-auto bg-surface-ground \
-                        font-normal text-text-color antialiased select-text"}>
-        <div>{renderTable()}</div>
-        <div className="mt-4 text-lg">Total Rows: {rows.length}</div>
-      </main>
-    </div>
+    </>
   );
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -101,7 +101,7 @@ export default function Home() {
 
 
   const getWeatherIndex = (stat) => {
-    const failRate = (stat.fails + stat.skips) / stat.runs;
+    const failRate = (stat.fails + stat.skips) / (stat.runs + stat.reruns);
     let idx = Math.floor((failRate * 10) / 2);
     if (idx === icons.length) idx -= 1;
     return isNaN(idx) ? 4 : idx;

--- a/pages/index.js
+++ b/pages/index.js
@@ -84,9 +84,8 @@ export default function Home() {
     return filteredJobs.filter((job) => {
         const jobName = job.name.toLowerCase();
         return values.every((val) => {
-            const decodedValue = decodeURIComponent(val)
-                .replace("/", "").trim().toLowerCase();
-            return jobName.includes(decodedValue); // Directly check contains
+            const decodedValue = decodeURIComponent(val).toLowerCase();
+            return jobName.includes(decodedValue);
         });
     });
   };
@@ -96,9 +95,8 @@ export default function Home() {
     return filteredJobs.filter((job) => {
         const jobName = job.name.toLowerCase();
         return values.some((val) => {
-            const decodedValue = decodeURIComponent(val)
-                .replace("/", "").trim().toLowerCase();
-            return jobName.includes(decodedValue); // Directly check contains
+            const decodedValue = decodeURIComponent(val).toLowerCase();
+            return jobName.includes(decodedValue); 
         });
     });
   };
@@ -292,7 +290,7 @@ export default function Home() {
     // Prevent the default behavior so that we can keep search terms.
     e.preventDefault();
     const matchMode = e.target.matchMode.value;
-    const value = e.target.value.value.trim(); 
+    const value = e.target.value.value.trimEnd(); 
     if (value) {  
       // Append the new matchMode regardless of if search terms were kept.
       const path = new URLSearchParams();
@@ -301,9 +299,7 @@ export default function Home() {
         // If keepSearch is true, add existing parameters in the URL.
         const urlParams = new URLSearchParams(window.location.search);
         urlParams.getAll("value").forEach((val) => {
-          const decodedValue = val
-            .replace("/", "").trim().toLowerCase();
-          path.append("value", decodedValue); 
+          path.append("value", val); 
         });
       }
       //Add the search term from the form and redirect. 

--- a/pages/index.js
+++ b/pages/index.js
@@ -213,7 +213,7 @@ export default function Home() {
           {runEntries.map(({
             run_num, 
             result, 
-            url, 
+            // url, 
             reruns, 
             rerun_result, 
             attempt_urls 
@@ -255,7 +255,7 @@ export default function Home() {
                       overlayRefs.current[badgeId].current.toggle(e)}>
                     <ul className="bg-white border rounded shadow-lg p-2">
                       {runStatuses.map((status, index) => (
-                        <li className="p-2 hover:bg-gray-200">
+                        <li key={index} className="p-2 hover:bg-gray-200">
                           <a 
                             href={attempt_urls[index]} 
                             target="_blank" 
@@ -377,7 +377,7 @@ export default function Home() {
         </div>
 
         <div className="flex flex-wrap mt-2 p-4 text-base">
-          <div className="space-x-2 pr-4 mx-auto lg:ml-0">
+          <div className="space-x-2 pr-4 mx-auto mb-2 lg:ml-0">
             <button 
               className={tabClass(display === "nightly")}
               onClick={() => setDisplay("nightly")}>
@@ -390,8 +390,8 @@ export default function Home() {
             </button>
           </div>
 
-          <div className="flex flex-col lg:flex-row items-center lg:space-x-4">
-            <form className="p-2 h-fit bg-gray-700 border-2 border-gray-600 flex flex-row" onSubmit={(e) => handleForm(e)}> 
+          <div className="flex flex-col lg:flex-row items-center lg:space-x-4 mx-auto lg:mr-0">
+            <form className="p-2 h-fit mb-2 bg-gray-700 border-2 border-gray-600 flex flex-row" onSubmit={(e) => handleForm(e)}> 
               <div>
                 <select name="matchMode" className="px-1 h-fit rounded-lg">
                   <option value="or">Match Any</option>
@@ -403,21 +403,23 @@ export default function Home() {
               </div>
               <button type="submit" className="bg-blue-500 text-white px-4  rounded-3xl">Submit</button>
             </form>
-            <button 
-              className={buttonClass()} 
-              onClick={() => clearSearch()}>
-              Clear Search
-            </button>
-            <button 
-              className={buttonClass(keepSearch)} 
-              onClick={() => setKeepSearch(!keepSearch)}>
-              Keep URL Search Terms
-            </button>
-            <button 
-              className={buttonClass(requiredFilter)} 
-              onClick={() => setRequiredFilter(!requiredFilter)}>
-              Required Jobs Only
-            </button>
+            <div className="flex mb-2 space-x2 flex-row lg:mr-0 lg:space-x-2">
+              <button 
+                className={buttonClass()} 
+                onClick={() => clearSearch()}>
+                Clear Search
+              </button>
+              <button 
+                className={buttonClass(keepSearch)} 
+                onClick={() => setKeepSearch(!keepSearch)}>
+                Keep URL Search Terms
+              </button>
+              <button 
+                className={buttonClass(requiredFilter)} 
+                onClick={() => setRequiredFilter(!requiredFilter)}>
+                Required Jobs Only
+              </button>
+            </div>
           </div>
         </div>
         

--- a/pages/index.js
+++ b/pages/index.js
@@ -205,7 +205,7 @@ export default function Home() {
                     <span className="p-overlay-badge" style={{ fontSize: '1rem' }}>
                     <sup
                       id={badgeId}
-                      style={{ fontSize: '0.7rem', verticalAlign: 'super', marginLeft: '0.3rem' }}
+                      className="text-xs font-bold align-super ml-1"
                     >
                       {reruns}
                     </sup>

--- a/pages/index.js
+++ b/pages/index.js
@@ -7,6 +7,7 @@ import { OverlayPanel } from 'primereact/overlaypanel';
 
 import NightlyData  from "../data/job_stats.json";
 import PRData       from "../data/check_stats.json";
+import MaintainerMapping from "../maintainers.yml";
 import { basePath } from "../next.config.js";
 import BarChart from './BarChart'; 
 
@@ -292,6 +293,10 @@ export default function Home() {
       attempt_urls: job.attempt_urls[idx],
     })); 
 
+    const maintainerData = MaintainerMapping.mappings
+      .filter(({ regex }) => new RegExp(regex).test(job.name))
+      .flatMap(match => match.owners);
+
     return (
       <div key={`${job.name}-runs`} className="p-3 bg-gray-100">
         <div className="flex flex-wrap gap-4">
@@ -357,15 +362,29 @@ export default function Home() {
             );
           })}
         </div>
-        <div>
-          <br/>Maintainer: <a 
-            href="https://github.com/sprt"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-blue-500 underline">
-              Aurelien Bombo
-          </a>
+        <div className="mt-4 p-2 bg-gray-300 w-fit">
+          {maintainerData.length > 0 ? (
+            <div>
+              Maintainers:{" "}
+              {maintainerData.map((owner, index) => (
+                <span key={index}>
+                  <a 
+                    href={`https://github.com/${owner.github}`} 
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-500 underline"
+                  >
+                    {owner.fullname}
+                  </a>
+                  {index < maintainerData.length - 1 && ", "}
+                </span>
+              ))}
+            </div>
+          ) : (
+            <div>No Maintainer Information Available</div>
+          )}
         </div>
+
       </div>
     );
   };

--- a/pages/index.js
+++ b/pages/index.js
@@ -97,17 +97,6 @@ export default function Home() {
     </div>
   );
 
-  const requiredCheckbox = (
-    <div>
-      <input
-        type="checkbox"
-        checked={requiredFilter}
-        onChange={(e) => setRequiredFilter(e.target.checked)}
-        style={{ height: "1rem", width: "1rem" }}
-      />
-    </div>
-  );
-
   const toggleRow = (rowData) => {
     setExpandedRows((prev) =>
       prev.includes(rowData) ? prev.filter((r) => r !== rowData) : [...prev, rowData]
@@ -123,6 +112,14 @@ export default function Home() {
   const rowExpansionTemplate = (data) => {
     const job = (display === "nightly" ? jobs : checks).find((job) => job.name === data.name);
   
+    if (!job) {
+      return (
+        <div className="p-3 bg-gray-100" style={{ marginLeft: "4.5rem", marginTop: "-2.0rem" }}>
+          <p>No data available for this job.</p>
+        </div>
+      );
+    }
+
     // Aggregate runs by run_num
     const aggregatedRuns = job.run_nums.reduce((acc, run_num, idx) => {
       const run = {
@@ -230,7 +227,6 @@ export default function Home() {
         filterHeader="Filter by Name"
         filterPlaceholder="Search..."
       />
-      <Column                    header = {requiredCheckbox}></Column>
       <Column field = "required" header = "Required" sortable />
       <Column field = {"runs"}   header = "Runs"     sortable />
       <Column field = {"fails"}  header = "Fails"    sortable />
@@ -278,6 +274,15 @@ export default function Home() {
           onClick={() => setKeepSearch(!keepSearch)}
         >
           Keep URL Search Terms
+        </button>
+
+        <button
+          className={`tab px-4 py-2 border-b-2 ${requiredFilter 
+            ? "border-blue-500 bg-gray-300" 
+            : "border-gray-300 bg-white"}`}
+          onClick={() => setRequiredFilter(!requiredFilter)}
+        >
+          Required Jobs Only
         </button>
       </div>
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -129,7 +129,6 @@ export default function Home() {
         run_num,
         result: job.results[idx],
         url: job.urls[idx],
-        attempts: display === "nightly" ? job.run_attempt[idx] : undefined,
       };
   
       if (!acc[run_num]) {
@@ -170,26 +169,12 @@ export default function Home() {
                   )
                   .map((run, index) => (
                     <div key={index} style={{ display: "flex", alignItems: "center", marginRight: "1rem" }}>
-                      {/* {display === "nightly" && (
-                        <p className="mr-1 font-bold">{run.attempts}</p> 
-                      )} */}
                       <a href={run.url} target="_blank">
                           {getRunStatusIcon(runs)} {run.run_num}
                       </a>
-                      {display === "nightly" && (
-                      <span className="p-overlay-badge" style={{ fontSize: '1rem' }}>
-                        <sup
-                          id={badgeId}
-                          style={{ fontSize: '0.7rem', verticalAlign: 'super', marginLeft: '0.3rem' }}
-                        >
-                          {run.attempts}
-                        </sup>
-                        {/* <Tooltip target={`#${badgeId}`} content={runStatuses} position="top" /> */}
-                      </span>
-                      )}
                   </div>
                 ))}
-                {display === "prchecks" && (
+                {count > 1 && (
                   <span className="p-overlay-badge" style={{ fontSize: '1rem' }}>
                     <sup
                       id={badgeId}

--- a/scripts/fetch-ci-nightly-data.js
+++ b/scripts/fetch-ci-nightly-data.js
@@ -185,17 +185,11 @@ function compute_job_stats(runs_with_job_data, required_jobs) {
       }
       job_stat["required"] = required_jobs.includes(job["name"]);
       
-      discovered = new Set();
       if(job["attempt_results"]){
         for(const result of job["attempt_results"]){
-          if(discovered.has(run["run_number"])){
-            job_stat["reruns"] += 1;
-          }else{
-            discovered.add(run["run_number"]);
-            job_stat["reruns"] += 2;
-          }
           job_stat["results"].push(result);
           job_stat["run_nums"].push(run["run_number"]);
+          job_stat["reruns"] += 1;
         }
       }
     }

--- a/scripts/fetch-ci-nightly-data.js
+++ b/scripts/fetch-ci-nightly-data.js
@@ -182,9 +182,11 @@ async function fetch_previous_attempt_url(prev_url) {
 // Using the previous URL, look at the json with jobs.
 // This will have the results for each job for a previous run. 
 async function fetch_attempt_results(prev_url) {
-  const result = []; // Initialize an array to hold all jobs
-  let p = 1; // Start from the first page
+  // Initialize an array to hold all jobs.
+  const result = []; 
 
+  // Fetch from pages until its processed all jobs.
+  let p = 1; 
   while (true) {
     const jobs_url = `${prev_url}/jobs?per_page=500&page=${p}`;
     const response = await fetch(jobs_url, {
@@ -201,18 +203,15 @@ async function fetch_attempt_results(prev_url) {
 
     const json = await response.json();
     fetch_count++;
-
-    // Add the fetched jobs to the allJobs array
     result.push(...json.jobs);
 
-    // Check if we have more pages to fetch
+    // Break we no have more pages to fetch.
     if (p * jobs_per_request >= json.total_count) {
-      break; // Exit the loop if we've fetched all jobs
+      break;
     }
-    p++; // Increment the page number for the next iteration
+    p++; 
   }
-
-  return { jobs: result }; // Return the jobs array
+  return { jobs: result };
 }
 
 

--- a/scripts/fetch-ci-nightly-data.js
+++ b/scripts/fetch-ci-nightly-data.js
@@ -44,7 +44,7 @@ const main_branch_url =
 const jobs_per_request = 500;
 
 // Count of the number of fetches.
-var fetch_count = 0;
+// var fetch_count = 0;
 
 
 // Perform a github API request for workflow runs.
@@ -83,7 +83,7 @@ async function fetch_main_branch() {
 
   const json = await response.json();
   fetch_count++;
-  const contexts = json?.protection?.required_status_checks?.contexts;
+  // const contexts = json?.protection?.required_status_checks?.contexts;
   return json;
 }
 

--- a/scripts/fetch-ci-nightly-data.js
+++ b/scripts/fetch-ci-nightly-data.js
@@ -22,7 +22,7 @@ const TOKEN = process.env.TOKEN;  // In dev, set by .env file; in prod, set by G
   
 // Github API URL for the kata-container ci-nightly workflow's runs. This
 // will only get the most recent 10 runs ('page' is empty, and 'per_page=10').
-var ci_nightly_runs_url =
+const ci_nightly_runs_url =
   "https://api.github.com/repos/" +
   "kata-containers/kata-containers/actions/workflows/" +
   "ci-nightly.yaml/runs?per_page=10";
@@ -30,7 +30,7 @@ var ci_nightly_runs_url =
 
 // Github API URL for the main branch of the kata-containers repo.
 // Used to get the list of required jobs.
-var main_branch_url = 
+const main_branch_url = 
   "https://api.github.com/repos/" +
   "kata-containers/kata-containers/branches/main";
 
@@ -88,7 +88,7 @@ function get_job_data(run) {
 
   // Perform the actual (paged) request
   async function fetch_jobs_by_page(which_page) {
-    var jobs_url =
+    const jobs_url =
       run["jobs_url"] + "?per_page=" + jobs_per_request + "&page=" + which_page;
     const response = await fetch(jobs_url, {
       headers: {
@@ -127,7 +127,7 @@ function get_job_data(run) {
     });
   }
 
-  var run_with_job_data = {
+  const run_with_job_data = {
     id: run["id"],
     run_number: run["run_number"],
     created_at: run["created_at"],
@@ -148,8 +148,7 @@ function get_job_data(run) {
 // Extract list of required jobs 
 // (i.e. main branch details: protection: required_status_checks: contexts)
 function get_required_jobs(main_branch) {
-  var required_jobs = main_branch["protection"]["required_status_checks"]["contexts"];
-  return required_jobs;
+  return main_branch["protection"]["required_status_checks"]["contexts"];
 }
 
 // Calculate and return job stats across all runs
@@ -168,7 +167,7 @@ function compute_job_stats(runs_with_job_data, required_jobs) {
           reruns: 0,    // the total number of times the test was rerun
         };
       }
-      var job_stat = job_stats[job["name"]];
+      const job_stat = job_stats[job["name"]];
       job_stat["runs"] += 1;
       job_stat["run_nums"].push(run["run_number"]);
       job_stat["urls"].push(job["html_url"]);
@@ -207,7 +206,7 @@ function compute_job_stats(runs_with_job_data, required_jobs) {
   
 // Using the previous URL, fetch the json to get the next URL        
 async function fetch_previous_attempt_url(prev_url) {   
-  var jobs_url = `${prev_url}?per_page=${jobs_per_request}&page=1`;
+  const jobs_url = `${prev_url}?per_page=${jobs_per_request}&page=1`;
   const response = await fetch(jobs_url, {
     headers: {
       Accept: "application/vnd.github+json",
@@ -228,7 +227,7 @@ async function fetch_previous_attempt_url(prev_url) {
 // Using the previous URL, look at the json with jobs
 // This will have the results for each job for a previous run. 
 async function fetch_attempt_results(prev_url) {   
-  var jobs_url = `${prev_url}/jobs`;
+  const jobs_url = `${prev_url}/jobs`;
   const response = await fetch(jobs_url, {
     headers: {
       Accept: "application/vnd.github+json",
@@ -309,15 +308,15 @@ async function get_atttempt_results(runs_with_job_data){
 
 async function main() {
   // Fetch recent workflow runs via the github API
-  var workflow_runs = await fetch_workflow_runs();
+  const workflow_runs = await fetch_workflow_runs();
 
   // Fetch required jobs from main branch
-  var main_branch = await fetch_main_branch();
-  var required_jobs = get_required_jobs(main_branch);
+  const main_branch = await fetch_main_branch();
+  const required_jobs = get_required_jobs(main_branch);
 
   // Fetch job data for each of the runs.
   // Store all of this in an array of maps, runs_with_job_data.
-  var promises_buf = [];
+  const promises_buf = [];
   for (const run of workflow_runs["workflow_runs"]) {
     promises_buf.push(get_job_data(run));
   }
@@ -329,7 +328,7 @@ async function main() {
   // Transform the raw details of each run and its jobs' results into a
   // an array of just the jobs and their overall results (e.g. pass or fail,
   // and the URLs associated with them).
-  var job_stats = compute_job_stats(runs_with_job_data, required_jobs);
+  const job_stats = compute_job_stats(runs_with_job_data, required_jobs);
 
   // Write the job_stats to console as a JSON object
   console.log(JSON.stringify(job_stats));

--- a/scripts/fetch-ci-nightly-data.js
+++ b/scripts/fetch-ci-nightly-data.js
@@ -40,7 +40,7 @@ const main_branch_url =
 
 // The number of jobs to fetch from the github API on each paged request.
 // If set to >= the number of jobs, will only need to fetch one page.
-// Could set upper limit (won't cause error)
+// Could set an upper limit to reduce fetches
 const jobs_per_request = 500;
 
 // Count of the number of fetches.

--- a/scripts/fetch-ci-nightly-data.js
+++ b/scripts/fetch-ci-nightly-data.js
@@ -45,7 +45,7 @@ async function fetch_workflow_runs() {
   const response = await fetch(ci_nightly_runs_url, {
     headers: {
       Accept: "application/vnd.github+json",
-      Authorization: TOKEN,
+      Authorization: `token ${TOKEN}`,
       "X-GitHub-Api-Version": "2022-11-28",
     },
   });
@@ -56,8 +56,8 @@ async function fetch_workflow_runs() {
 
   const json = await response.json();
   fetch_count++;
-  console.log(`fetch ${fetch_count}: ${ci_nightly_runs_url}
-      returned workflow cnt / total cnt: ${json['workflow_runs'].length} / ${json['total_count']}`);
+  // console.log(`fetch ${fetch_count}: ${ci_nightly_runs_url}
+  //     returned workflow cnt / total cnt: ${json['workflow_runs'].length} / ${json['total_count']}`);
   return await json;
 }
 
@@ -67,7 +67,7 @@ async function fetch_main_branch() {
   const response = await fetch(main_branch_url, {
     headers: {
       Accept: "application/vnd.github+json",
-      Authorization: TOKEN,
+      Authorization: `token ${TOKEN}`,
       "X-GitHub-Api-Version": "2022-11-28",
     },
   });
@@ -79,8 +79,8 @@ async function fetch_main_branch() {
   const json = await response.json();
   fetch_count++;
   const contexts = json?.protection?.required_status_checks?.contexts;
-  console.log(`fetch ${fetch_count}: ${main_branch_url}
-      required jobs cnt: ${contexts.length}`);
+  // console.log(`fetch ${fetch_count}: ${main_branch_url}
+  //     required jobs cnt: ${contexts.length}`);
   return json;
 }
 
@@ -99,7 +99,7 @@ function get_job_data(run) {
     const response = await fetch(jobs_url, {
       headers: {
         Accept: "application/vnd.github+json",
-        Authorization: TOKEN,
+        Authorization: `token ${TOKEN}`,
         "X-GitHub-Api-Version": "2022-11-28",
       },
     });
@@ -110,8 +110,8 @@ function get_job_data(run) {
 
     const json = await response.json();
     fetch_count++;
-    console.log(`fetch ${fetch_count}: ${jobs_url}
-      returned jobs cnt / total cnt: ${json['jobs'].length} / ${json['total_count']}`);
+    // console.log(`fetch ${fetch_count}: ${jobs_url}
+    //   returned jobs cnt / total cnt: ${json['jobs'].length} / ${json['total_count']}`);
     return await json;
   }
 
@@ -220,11 +220,11 @@ async function main() {
   var job_stats = compute_job_stats(runs_with_job_data, required_jobs);
 
   // Write the job_stats to console as a JSON object
-  console.log('\n\n FINAL_RESULT: \n\n', JSON.stringify(job_stats));
+  console.log(JSON.stringify(job_stats));
   // console.log(JSON.stringify(required_jobs));
 
   // Print total number of jobs
-  console.log(`\n\nTotal job count: ${Object.keys(job_stats).length}\n\n`);
+  // console.log(`\n\nTotal job count: ${Object.keys(job_stats).length}\n\n`);
 }
 
 

--- a/scripts/fetch-ci-nightly-data.js
+++ b/scripts/fetch-ci-nightly-data.js
@@ -44,7 +44,7 @@ const main_branch_url =
 const jobs_per_request = 500;
 
 // Count of the number of fetches.
-// var fetch_count = 0;
+var fetch_count = 0;
 
 
 // Perform a github API request for workflow runs.

--- a/scripts/fetch-ci-nightly-data.js
+++ b/scripts/fetch-ci-nightly-data.js
@@ -125,6 +125,7 @@ function get_job_data(run) {
           run_id: job["run_id"],
           html_url: job["html_url"],
           conclusion: job["conclusion"],
+          run_attempt: job["run_attempt"],
         });
       }
       if (p * jobs_per_request >= jobs_request["total_count"]) {
@@ -138,6 +139,12 @@ function get_job_data(run) {
     id: run["id"],
     run_number: run["run_number"],
     created_at: run["created_at"],
+    // run_attempt: run["run_attempt"],
+    // To implement previous results as well, would have to traverse through
+    // all previous attempt URLs, extracting the job data again.
+    // The job data (conclusion) would also have to be stored in separate arrays,
+    // one for each attempt
+    // previous_attempt_url: run["previous_attempt_url"],
     conclusion: null,
     jobs: [],
   };
@@ -172,6 +179,7 @@ function compute_job_stats(runs_with_job_data, required_jobs) {
           urls: [], // ordered list of URLs associated w/ each run
           results: [], // an array of strings, e.g. 'Pass', 'Fail', ...
           run_nums: [], // ordered list of github-assigned run numbers
+          run_attempt: [], //  e.g. 5, if it was run 5 times
         };
       }
       var job_stat = job_stats[job["name"]];
@@ -191,6 +199,7 @@ function compute_job_stats(runs_with_job_data, required_jobs) {
         job_stat["results"].push("Pass");
       }
       job_stat["required"] = required_jobs.includes(job["name"]);
+      job_stat["run_attempt"].push(job["run_attempt"]);
     }
   }
   return job_stats;

--- a/scripts/fetch-ci-nightly-data.js
+++ b/scripts/fetch-ci-nightly-data.js
@@ -66,9 +66,11 @@ var fetch_count = 0;
 // Perform a github API request for workflow runs.
 async function fetch_workflow_runs() {
   fetch_count++;
+  console.log(`fetch ${fetch_count}: ${ci_nightly_runs_url}`);
   return fetch(ci_nightly_runs_url, {
     headers: {
       Accept: "application/vnd.github+json",
+      Authorization: process.env.TOKEN,
       "X-GitHub-Api-Version": "2022-11-28",
     },
   }).then(function (response) {
@@ -80,9 +82,11 @@ async function fetch_workflow_runs() {
 async function fetch_pull_requests() {
   fetch_count++;
   const prs_url = `${pull_requests_url}${pr_count}`;
+  console.log(`fetch ${fetch_count}: ${prs_url}`);
   return fetch(prs_url, {
     headers: {
       Accept: "application/vnd.github+json",
+      Authorization: process.env.TOKEN,
       "X-GitHub-Api-Version": "2022-11-28",
     },
   }).then(function (response) {
@@ -92,9 +96,12 @@ async function fetch_pull_requests() {
 
 // Perform a github API request for a list of "Required" jobs
 async function fetch_main_branch() {
+  fetch_count++;
+  console.log(`fetch ${fetch_count}: ${main_branch_url}`);
   return fetch(main_branch_url, {
     headers: {
       Accept: "application/vnd.github+json",
+      Authorization: process.env.TOKEN,
       "X-GitHub-Api-Version": "2022-11-28",
     },
   }).then(function (response) {
@@ -113,9 +120,11 @@ function get_job_data(run) {
     fetch_count++;
     var jobs_url =
       run["jobs_url"] + "?per_page=" + jobs_per_request + "&page=" + which_page;
+    console.log(`fetch ${fetch_count}: ${jobs_url}`);
     return fetch(jobs_url, {
       headers: {
         Accept: "application/vnd.github+json",
+        Authorization: process.env.TOKEN,
         "X-GitHub-Api-Version": "2022-11-28",
       },
     }).then(function (response) {
@@ -167,9 +176,11 @@ function get_check_data(pr) {
     fetch_count++;
     var checks_url = 
       pr_checks_url + prs_with_check_data["commit_sha"] + "/check-runs" + "?per_page=" + jobs_per_request + "&page=" + which_page;
+    console.log(`fetch ${fetch_count}: ${pr_checks_url}`);
     return fetch(checks_url, {  
       headers: {
         Accept: "application/vnd.github+json",
+        Authorization: process.env.TOKEN,
         "X-GitHub-Api-Version": "2022-11-28",
       },
     }).then(function (response) {

--- a/scripts/fetch-ci-nightly-data.js
+++ b/scripts/fetch-ci-nightly-data.js
@@ -11,17 +11,15 @@
 //     entry is information about a job and how it has performed over the last
 //     few runs (e.g. pass or fail).
 // 
-// Count of API calls:
-//     1 for the batch of last 10 nightly run
-//    20 for 2 batches of >100 jobs for each of the 10 runs
-//     1 for the main branch details (for list of 'Required' jobs)
-//     1 for the last 10 closed pull requests
-//    20 for all 4 batches of checks (max of a hundred each) for each of the 5 PRs
-//     X Other?
-// TOTAL: 43?
-// LIMIT: 60 per hour  // curl https://api.github.com/rate_limit
-// TODO: Further explore using the GraphQL API, which permits more narrowly targeted queries 
+// To run locally:
+// node --require dotenv/config scripts/fetch-ci-nightly-data.js
+// .env file with:
+// NODE_ENV=development
+// TOKEN=token <GITHUB_PAT_OR_OTHER_VALID_TOKEN>
 
+// Set token used for making Authorized GitHub API calls
+const TOKEN = process.env.TOKEN;  // In dev, set by .env file; in prod, set by GitHub Secret
+  
 // Github API URL for the kata-container ci-nightly workflow's runs. This
 // will only get the most recent 10 runs ('page' is empty, and 'per_page=10').
 var ci_nightly_runs_url =
@@ -29,24 +27,6 @@ var ci_nightly_runs_url =
   "kata-containers/kata-containers/actions/workflows/" +
   "ci-nightly.yaml/runs?per_page=10";
   // NOTE: For checks run on main after push/merge, do similar call with: payload-after-push.yaml
-
-// NOTE: pull_requests attribute often empty if commit/branch from a fork: https://github.com/orgs/community/discussions/25220
-// Current approach (there may be better alternatives) is to:
-//   1. retrieve the last 10 closed PRs
-//   2. fetch the checks for each PR (using the head commit SHA)
-var pull_requests_url =
-  "https://api.github.com/repos/" +
-  "kata-containers/kata-containers/pulls?state=closed&per_page=";
-var pr_checks_url =  // for our purposes, 'check' refers to a job in the context of a PR
-  "https://api.github.com/repos/" +
-  "kata-containers/kata-containers/commits/";  // will be followed by {commit_sha}/check-runs
-  // Max of 100 per page, w/ little *over* 300 checks total, so that's 40 calls total for 10 PRs
-
-// Github API URL for the main branch of the kata-containers repo.
-// Used to get the list of required jobs.
-var main_branch_url = 
-  "https://api.github.com/repos/" +
-  "kata-containers/kata-containers/branches/main";
 
 // Github API URL for the main branch of the kata-containers repo.
 // Used to get the list of required jobs.
@@ -56,58 +36,54 @@ var main_branch_url =
 
 // The number of jobs to fetch from the github API on each paged request.
 var jobs_per_request = 100;
-// The last X closed PRs to retrieve
-var pr_count = 5; 
-// Complete list of jobs (from the CI nightly run)
-var job_names = new Set();
 // Count of the number of fetches
 var fetch_count = 0;
 
+
 // Perform a github API request for workflow runs.
 async function fetch_workflow_runs() {
-  fetch_count++;
-  console.log(`fetch ${fetch_count}: ${ci_nightly_runs_url}`);
-  return fetch(ci_nightly_runs_url, {
+  const response = await fetch(ci_nightly_runs_url, {
     headers: {
       Accept: "application/vnd.github+json",
-      Authorization: process.env.TOKEN,
+      Authorization: TOKEN,
       "X-GitHub-Api-Version": "2022-11-28",
     },
-  }).then(function (response) {
-    return response.json();
   });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch workflow runs: ${response.status}`);
+  }
+
+  const json = await response.json();
+  fetch_count++;
+  console.log(`fetch ${fetch_count}: ${ci_nightly_runs_url}
+      returned workflow cnt / total cnt: ${json['workflow_runs'].length} / ${json['total_count']}`);
+  return await json;
 }
 
-// Perform a github API request for the last pr_count closed PRs
-async function fetch_pull_requests() {
-  fetch_count++;
-  const prs_url = `${pull_requests_url}${pr_count}`;
-  console.log(`fetch ${fetch_count}: ${prs_url}`);
-  return fetch(prs_url, {
-    headers: {
-      Accept: "application/vnd.github+json",
-      Authorization: process.env.TOKEN,
-      "X-GitHub-Api-Version": "2022-11-28",
-    },
-  }).then(function (response) {
-    return response.json();
-  });
-}
 
 // Perform a github API request for a list of "Required" jobs
 async function fetch_main_branch() {
-  fetch_count++;
-  console.log(`fetch ${fetch_count}: ${main_branch_url}`);
-  return fetch(main_branch_url, {
+  const response = await fetch(main_branch_url, {
     headers: {
       Accept: "application/vnd.github+json",
-      Authorization: process.env.TOKEN,
+      Authorization: TOKEN,
       "X-GitHub-Api-Version": "2022-11-28",
     },
-  }).then(function (response) {
-    return response.json();
   });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch main branch: ${response.status}`);
+  }
+
+  const json = await response.json();
+  fetch_count++;
+  const contexts = json?.protection?.required_status_checks?.contexts;
+  console.log(`fetch ${fetch_count}: ${main_branch_url}
+      required jobs cnt: ${contexts.length}`);
+  return json;
 }
+
 
 // Get job data about a workflow run
 // Returns a map that has information about a run, e.g.
@@ -115,21 +91,28 @@ async function fetch_main_branch() {
 //   run number assigned by github
 //   'jobs' array, which has some details about each job from that run
 function get_job_data(run) {
+
   // Perform the actual (paged) request
   async function fetch_jobs_by_page(which_page) {
-    fetch_count++;
     var jobs_url =
       run["jobs_url"] + "?per_page=" + jobs_per_request + "&page=" + which_page;
-    console.log(`fetch ${fetch_count}: ${jobs_url}`);
-    return fetch(jobs_url, {
+    const response = await fetch(jobs_url, {
       headers: {
         Accept: "application/vnd.github+json",
-        Authorization: process.env.TOKEN,
+        Authorization: TOKEN,
         "X-GitHub-Api-Version": "2022-11-28",
       },
-    }).then(function (response) {
-      return response.json();
     });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch jobs: ${response.status}`);
+    }
+
+    const json = await response.json();
+    fetch_count++;
+    console.log(`fetch ${fetch_count}: ${jobs_url}
+      returned jobs cnt / total cnt: ${json['jobs'].length} / ${json['total_count']}`);
+    return await json;
   }
 
   // Fetch the jobs for a run. Extract a few details from the response,
@@ -137,9 +120,6 @@ function get_job_data(run) {
   function fetch_jobs(p) {
     return fetch_jobs_by_page(p).then(function (jobs_request) {
       for (const job of jobs_request["jobs"]) {
-        if (!job_names.has(job["name"])) {
-          job_names.add(job["name"])
-        };
         run_with_job_data["jobs"].push({
           name: job["name"],
           run_id: job["run_id"],
@@ -170,64 +150,6 @@ function get_job_data(run) {
   return fetch_jobs(1);
 }
 
-function get_check_data(pr) {
-  // Perform a github API request for a list of commits for a PR (takes in the PR's head commit SHA)
-  async function fetch_checks_by_page(which_page) {
-    fetch_count++;
-    var checks_url = 
-      pr_checks_url + prs_with_check_data["commit_sha"] + "/check-runs" + "?per_page=" + jobs_per_request + "&page=" + which_page;
-    console.log(`fetch ${fetch_count}: ${pr_checks_url}`);
-    return fetch(checks_url, {  
-      headers: {
-        Accept: "application/vnd.github+json",
-        Authorization: process.env.TOKEN,
-        "X-GitHub-Api-Version": "2022-11-28",
-      },
-    }).then(function (response) {
-      return response.json();
-    });
-  }
-
-  // Fetch the checks for a PR.
-  function fetch_checks(p) {
-    if (p > 60) {
-      throw new Error(`Attempting to make too many API calls: ${p}`)
-    }
-    return fetch_checks_by_page(p)
-    .then(function (checks_request) {
-      // console.log('checks_request', checks_request);
-      for (const check of checks_request["check_runs"]) {
-        // NOTE: For now, excluding checks that are not also run in CI Nightly
-        if (job_names.has(check["name"])) {  
-          prs_with_check_data["checks"].push({
-            name: check["name"],
-            conclusion: check["conclusion"]
-          });
-        }
-      }
-      if (p * jobs_per_request >= checks_request["total_count"]) {
-        return prs_with_check_data;
-      }
-      return fetch_checks(p + 1);
-    })
-    .catch(function (error) {
-      console.error("Error fetching checks:", error);
-      throw error;
-    });
-  }
-
-  // Extract list of objects with PR commit SHAs, PR URLs, and PR number (i.e. id)
-  var prs_with_check_data = {
-    html_url: pr["html_url"],  // link to PR page
-    number: pr["number"],  // PR number (used as PR id); displayed on dashboard
-    commit_sha: pr["head"]["sha"],  // For getting checks run on PR branch
-    // commit_sha: pr["merge_commit_sha"],  // For getting checks run on main branch after merge
-    // NOTE: using for now b/c we'll be linking to the PR page, where these checks are listed...
-    checks: [],  // will be populated later with fetch_checks
-  };
-
-  return fetch_checks(1);
-}
 
 // Extract list of required jobs (i.e. main branch details: protection: required_status_checks: contexts)
 function get_required_jobs(main_branch) {
@@ -236,8 +158,9 @@ function get_required_jobs(main_branch) {
   return required_jobs;
 }
 
+
 // Calculate and return job stats across all runs
-function compute_job_stats(runs_with_job_data, prs_with_check_data, required_jobs) {
+function compute_job_stats(runs_with_job_data, required_jobs) {
   var job_stats = {};
   for (const run of runs_with_job_data) {
     for (const job of run["jobs"]) {
@@ -249,13 +172,6 @@ function compute_job_stats(runs_with_job_data, prs_with_check_data, required_job
           urls: [], // ordered list of URLs associated w/ each run
           results: [], // an array of strings, e.g. 'Pass', 'Fail', ...
           run_nums: [], // ordered list of github-assigned run numbers
-
-          pr_runs: 0,
-          pr_fails: 0,
-          pr_skips: 0,
-          pr_urls: [], // list of PR URLs that this job is associated with
-          pr_results: [], // list of job statuses for the PRs in which the job was run
-          pr_nums: [], // list of PR numbers that this job is associated with
         };
       }
       var job_stat = job_stats[job["name"]];
@@ -277,30 +193,9 @@ function compute_job_stats(runs_with_job_data, prs_with_check_data, required_job
       job_stat["required"] = required_jobs.includes(job["name"]);
     }
   }
-  for (const pr of prs_with_check_data) {
-    for (const check of pr["checks"]) {
-      if ((check["name"] in job_stats)) {
-        var job_stat = job_stats[check["name"]];
-        job_stat["pr_runs"] += 1;
-        job_stat["pr_urls"].push(pr["html_url"])
-        job_stat["pr_nums"].push(pr["number"])
-        if (check["conclusion"] != "success") {
-          if (check["conclusion"] == "skipped") {
-            job_stat["pr_skips"] += 1;
-            job_stat["pr_results"].push("Skip");
-          } else {
-            // failed or cancelled
-            job_stat["pr_fails"] += 1;
-            job_stat["pr_results"].push("Fail");
-          }
-        } else {
-          job_stat["pr_results"].push("Pass");
-        }
-      }
-    }
-  }
   return job_stats;
 }
+
 
 async function main() {
   // Fetch recent workflow runs via the github API
@@ -308,6 +203,7 @@ async function main() {
 
   // Fetch required jobs from main branch
   var main_branch = await fetch_main_branch();
+  // console.log('main_branch: ', main_branch);
   var required_jobs = get_required_jobs(main_branch);
 
   // Fetch job data for each of the runs.
@@ -318,25 +214,17 @@ async function main() {
   }
   runs_with_job_data = await Promise.all(promises_buf);
 
-  // Fetch recent pull requests via the github API
-  var pull_requests = await fetch_pull_requests();
-
-  // Fetch last pr_count closed PRs
-  // Store all of this in an array of maps, prs_with_check_data.
-  var promises_buffer = [];
-  for (const pr of pull_requests) {
-    promises_buffer.push(get_check_data(pr));
-  }
-  prs_with_check_data = await Promise.all(promises_buffer);
-
   // Transform the raw details of each run and its jobs' results into a
   // an array of just the jobs and their overall results (e.g. pass or fail,
   // and the URLs associated with them).
-  var job_stats = compute_job_stats(runs_with_job_data, prs_with_check_data, required_jobs);
+  var job_stats = compute_job_stats(runs_with_job_data, required_jobs);
 
   // Write the job_stats to console as a JSON object
-  console.log(JSON.stringify(job_stats));
+  console.log('\n\n FINAL_RESULT: \n\n', JSON.stringify(job_stats));
   // console.log(JSON.stringify(required_jobs));
+
+  // Print total number of jobs
+  console.log(`\n\nTotal job count: ${Object.keys(job_stats).length}\n\n`);
 }
 
 

--- a/scripts/fetch-ci-nightly-data.js
+++ b/scripts/fetch-ci-nightly-data.js
@@ -154,19 +154,18 @@ function get_required_jobs(main_branch) {
 
 // Calculate and return job stats across all runs
 function compute_job_stats(runs_with_job_data, required_jobs) {
-  var job_stats = {};
+  const job_stats = {};
   for (const run of runs_with_job_data) {
     for (const job of run["jobs"]) {
       if (!(job["name"] in job_stats)) {
         job_stats[job["name"]] = {
-          runs: 0, // e.g. 10, if it ran 10 times
-          fails: 0, // e.g. 3, if it failed 3 out of 10 times
-          skips: 0, // e.g. 7, if it got skipped the other 7 times
-          urls: [], // ordered list of URLs associated w/ each run
-          results: [], // an array of strings, e.g. 'Pass', 'Fail', ...
+          runs: 0,      // e.g. 10, if it ran 10 times
+          fails: 0,     // e.g. 3, if it failed 3 out of 10 times
+          skips: 0,     // e.g. 7, if it got skipped the other 7 times
+          urls: [],     // ordered list of URLs associated w/ each run
+          results: [],  // an array of strings, e.g. 'Pass', 'Fail', ...
           run_nums: [], // ordered list of github-assigned run numbers
-          // run_attempt: [], //  e.g. 5, if it was run 5 times
-          // attempt_results: [],
+          reruns: 0,    // the total number of times the test was rerun
         };
       }
       var job_stat = job_stats[job["name"]];
@@ -186,15 +185,20 @@ function compute_job_stats(runs_with_job_data, required_jobs) {
         job_stat["results"].push("Pass");
       }
       job_stat["required"] = required_jobs.includes(job["name"]);
-      // job_stat["run_attempt"].push(job["run_attempt"]);
-
+      
+      discovered = new Set();
       if(job["attempt_results"]){
         for(const result of job["attempt_results"]){
+          if(discovered.has(run["run_number"])){
+            job_stat["reruns"] += 1;
+          }else{
+            discovered.add(run["run_number"]);
+            job_stat["reruns"] += 2;
+          }
           job_stat["results"].push(result);
           job_stat["run_nums"].push(run["run_number"]);
         }
       }
-      // job_stat["attempt_results"].push(job["attempt_results"]);
     }
   }
   return job_stats;

--- a/scripts/fetch-ci-pr-data.js
+++ b/scripts/fetch-ci-pr-data.js
@@ -31,11 +31,9 @@ const main_branch_url =
   "kata-containers/kata-containers/branches/main";
 
 // The number of checks to fetch from the github API on each paged request.
-// If set to >= the number of jobs, will only need to fetch one page.
-// Could set an upper limit to reduce fetches
-const results_per_request = 500;
+const results_per_request = 100;
 // The last X closed PRs to retrieve
-const pr_count = 10; 
+const pr_count = 20; 
 // Count of the number of fetches
 var fetch_count = 0;
 

--- a/scripts/fetch-ci-pr-data.js
+++ b/scripts/fetch-ci-pr-data.js
@@ -35,7 +35,7 @@ const results_per_request = 100;
 // The last X closed PRs to retrieve
 const pr_count = 10; 
 // Count of the number of fetches
-var fetch_count = 0;
+// var fetch_count = 0;
 
 
 // Perform a github API request for the last pr_count closed PRs
@@ -77,7 +77,7 @@ async function fetch_main_branch() {
 
     const json = await response.json();
     fetch_count += 1;
-    const contexts = json?.protection?.required_status_checks?.contexts;
+    // const contexts = json?.protection?.required_status_checks?.contexts;
     // console.log(`fetch ${fetch_count}: ${main_branch_url}
     //     required jobs cnt: ${contexts.length}`);
     return json;

--- a/scripts/fetch-ci-pr-data.js
+++ b/scripts/fetch-ci-pr-data.js
@@ -1,0 +1,227 @@
+//
+// This script is designed to query the github API for a useful summary
+// of recent PR CI tests.
+//
+// The general flow is as follows:
+//   1. retrieve the last 10 closed PRs
+//   2. fetch the checks for each PR (using the head commit SHA)
+//
+// To run locally:
+// node --require dotenv/config scripts/fetch-ci-pr-data.js
+// .env file with:
+// NODE_ENV=development
+// TOKEN=token <GITHUB_PAT_OR_OTHER_VALID_TOKEN>
+
+
+// Set token used for making Authorized GitHub API calls
+const TOKEN = process.env.TOKEN;  // In dev, set by .env file; in prod, set by GitHub Secret
+  
+// pull_requests attribute often empty if commit/branch from a fork: https://github.com/orgs/community/discussions/25220
+var pull_requests_url =
+  "https://api.github.com/repos/" +
+  "kata-containers/kata-containers/pulls?state=closed&per_page=";
+var pr_checks_url =  // for our purposes, 'check' refers to a job in the context of a PR
+  "https://api.github.com/repos/" +
+  "kata-containers/kata-containers/commits/";  // will be followed by {commit_sha}/check-runs
+  // Max of 100 per page, w/ little *over* 300 checks total, so that's 40 calls total for 10 PRs
+
+// Github API URL for the main branch of the kata-containers repo.
+// Used to get the list of required jobs/checks.
+var main_branch_url = 
+  "https://api.github.com/repos/" +
+  "kata-containers/kata-containers/branches/main";
+
+
+// The number of checks to fetch from the github API on each paged request.
+var results_per_request = 100;
+// The last X closed PRs to retrieve
+var pr_count = 10; 
+// Count of the number of fetches
+var fetch_count = 0;
+
+
+// Perform a github API request for the last pr_count closed PRs
+async function fetch_pull_requests() {
+    const prs_url = `${pull_requests_url}${pr_count}`;
+    const response = await fetch(prs_url, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: TOKEN,
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    });
+  
+    if (!response.ok) {
+      throw new Error(`Failed to fetch pull requests: ${response.status}`);
+    }
+  
+    const json = await response.json();
+    fetch_count++;
+    console.log(`fetch ${fetch_count}: ${prs_url}
+        returned PRs cnt: ${Object.keys(json).length}`);
+    return json;
+}
+
+
+// Perform a github API request for a list of "Required" jobs
+async function fetch_main_branch() {
+    const response = await fetch(main_branch_url, {
+        headers: {
+            Accept: "application/vnd.github+json",
+            Authorization: TOKEN,
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    });
+
+    if (!response.ok) {
+    throw new Error(`Failed to fetch main branch data: ${response.status}`);
+    }
+
+    const json = await response.json();
+    fetch_count++;
+    const contexts = json?.protection?.required_status_checks?.contexts;
+    console.log(`fetch ${fetch_count}: ${main_branch_url}
+        required jobs cnt: ${contexts.length}`);
+    return json;
+}
+
+
+// Perform a github API request for a list of commits for a PR (takes in the PR's head commit SHA)
+function get_check_data(pr) {
+  async function fetch_checks_by_page(which_page) {
+    var checks_url = `${pr_checks_url}${prs_with_check_data["commit_sha"]}/check-runs?per_page=${results_per_request}&page=${which_page}`;
+    const response = await fetch(checks_url, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: TOKEN,
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch check data: ${response.status}`);
+    }
+
+    const json = await response.json();
+    fetch_count++;
+    console.log(`fetch ${fetch_count}: ${checks_url}
+        returned check cnt / total cnt: ${json['check_runs'].length} / ${json['total_count']}`);
+    return json;
+  }
+
+  // Fetch the checks for a PR.
+  function fetch_checks(p) {
+    return fetch_checks_by_page(p)
+    .then(function (checks_request) {
+      // console.log('checks_request', checks_request);
+      for (const check of checks_request["check_runs"]) {
+        prs_with_check_data["checks"].push({
+            name: check["name"],
+            conclusion: check["conclusion"]
+        });
+      }
+      if (p * results_per_request >= checks_request["total_count"]) {
+        return prs_with_check_data;
+      }
+      return fetch_checks(p + 1);
+    })
+    .catch(function (error) {
+      console.error("Error fetching checks:", error);
+      throw error;
+    });
+  }
+
+  // Extract list of objects with PR commit SHAs, PR URLs, and PR number (i.e. id)
+  var prs_with_check_data = {
+    html_url: pr["html_url"],  // link to PR page
+    number: pr["number"],  // PR number (used as PR id); displayed on dashboard
+    commit_sha: pr["head"]["sha"],  // For getting checks run on PR branch
+    // commit_sha: pr["merge_commit_sha"],  // For getting checks run on main branch after merge
+    // NOTE: using for now b/c we'll be linking to the PR page, where these checks are listed...
+    checks: [],  // will be populated later with fetch_checks
+  };
+
+  return fetch_checks(1);
+}
+
+
+// Extract list of required jobs (i.e. main branch details: protection: required_status_checks: contexts)
+function get_required_jobs(main_branch) {
+  var required_jobs = main_branch["protection"]["required_status_checks"]["contexts"];
+  // console.log('required jobs: ', required_jobs);
+  return required_jobs;
+}
+
+
+// Calculate and return check stats across all runs
+function compute_check_stats(prs_with_check_data, required_jobs) {
+  var check_stats = {};
+  for (const pr of prs_with_check_data) {
+    for (const check of pr["checks"]) {
+        if (!(check["name"] in check_stats)) {
+            check_stats[check["name"]] = {
+                runs: 0,     // e.g. 10, if it ran 10 times
+                fails: 0,    // e.g. 3, if it failed 3 out of 10 times
+                skips: 0,    // e.g. 7, if it got skipped the other 7 times
+                urls: [],    // list of PR URLs that this check is associated with
+                results: [], // list of check statuses for the PRs in which the check was run
+                run_nums: [],    // list of PR numbers that this check is associated with
+            };
+        }
+        if ((check["name"] in check_stats)) {
+            var check_stat = check_stats[check["name"]];
+            check_stat["runs"] += 1;
+            check_stat["urls"].push(pr["html_url"])
+            check_stat["run_nums"].push(pr["number"])
+            if (check["conclusion"] != "success") {
+            if (check["conclusion"] == "skipped") {
+                check_stat["skips"] += 1;
+                check_stat["results"].push("Skip");
+            } else {
+                // failed or cancelled
+                check_stat["fails"] += 1;
+                check_stat["results"].push("Fail");
+            }
+            } else {
+            check_stat["results"].push("Pass");
+            }
+            check_stat["required"] = required_jobs.includes(check["name"]);
+        }
+    }
+  }
+  return check_stats;
+}
+
+
+async function main() {
+  // Fetch required jobs from main branch
+  var main_branch = await fetch_main_branch();
+  var required_jobs = get_required_jobs(main_branch);
+
+  // Fetch recent pull requests via the github API
+  var pull_requests = await fetch_pull_requests();
+
+  // Fetch last pr_count closed PRs
+  // Store all of this in an array of maps, prs_with_check_data.
+  var promises_buffer = [];
+  for (const pr of pull_requests) {
+    promises_buffer.push(get_check_data(pr));
+  }
+  prs_with_check_data = await Promise.all(promises_buffer);
+  // console.log("prs_with_check_data: ", prs_with_check_data);
+  
+  // Transform the raw details of each run and its checks' results into a
+  // an array of just the checks and their overall results (e.g. pass or fail,
+  // and the URLs associated with them).
+  var check_stats = compute_check_stats(prs_with_check_data, required_jobs);
+
+  // Write the check_stats to console as a JSON object
+  console.log('\n\n FINAL_RESULT: \n\n', JSON.stringify(check_stats));
+  // console.log(JSON.stringify(required_jobs));
+
+  // Print total number of jobs
+  console.log(`\n\nTotal job count: ${Object.keys(check_stats).length}\n\n`);
+}
+
+
+main();

--- a/scripts/fetch-ci-pr-data.js
+++ b/scripts/fetch-ci-pr-data.js
@@ -46,7 +46,7 @@ async function fetch_pull_requests() {
     const response = await fetch(prs_url, {
       headers: {
         Accept: "application/vnd.github+json",
-        Authorization: TOKEN,
+        Authorization: `token ${TOKEN}`,
         "X-GitHub-Api-Version": "2022-11-28",
       },
     });
@@ -57,8 +57,8 @@ async function fetch_pull_requests() {
   
     const json = await response.json();
     fetch_count++;
-    console.log(`fetch ${fetch_count}: ${prs_url}
-        returned PRs cnt: ${Object.keys(json).length}`);
+    // console.log(`fetch ${fetch_count}: ${prs_url}
+    //     returned PRs cnt: ${Object.keys(json).length}`);
     return json;
 }
 
@@ -68,7 +68,7 @@ async function fetch_main_branch() {
     const response = await fetch(main_branch_url, {
         headers: {
             Accept: "application/vnd.github+json",
-            Authorization: TOKEN,
+            Authorization: `token ${TOKEN}`,
             "X-GitHub-Api-Version": "2022-11-28",
         },
     });
@@ -80,8 +80,8 @@ async function fetch_main_branch() {
     const json = await response.json();
     fetch_count++;
     const contexts = json?.protection?.required_status_checks?.contexts;
-    console.log(`fetch ${fetch_count}: ${main_branch_url}
-        required jobs cnt: ${contexts.length}`);
+    // console.log(`fetch ${fetch_count}: ${main_branch_url}
+    //     required jobs cnt: ${contexts.length}`);
     return json;
 }
 
@@ -93,7 +93,7 @@ function get_check_data(pr) {
     const response = await fetch(checks_url, {
       headers: {
         Accept: "application/vnd.github+json",
-        Authorization: TOKEN,
+        Authorization: `token ${TOKEN}`,
         "X-GitHub-Api-Version": "2022-11-28",
       },
     });
@@ -104,8 +104,8 @@ function get_check_data(pr) {
 
     const json = await response.json();
     fetch_count++;
-    console.log(`fetch ${fetch_count}: ${checks_url}
-        returned check cnt / total cnt: ${json['check_runs'].length} / ${json['total_count']}`);
+    // console.log(`fetch ${fetch_count}: ${checks_url}
+    //     returned check cnt / total cnt: ${json['check_runs'].length} / ${json['total_count']}`);
     return json;
   }
 
@@ -216,11 +216,11 @@ async function main() {
   var check_stats = compute_check_stats(prs_with_check_data, required_jobs);
 
   // Write the check_stats to console as a JSON object
-  console.log('\n\n FINAL_RESULT: \n\n', JSON.stringify(check_stats));
+  console.log(JSON.stringify(check_stats));
   // console.log(JSON.stringify(required_jobs));
 
   // Print total number of jobs
-  console.log(`\n\nTotal job count: ${Object.keys(check_stats).length}\n\n`);
+  // console.log(`\n\nTotal job count: ${Object.keys(check_stats).length}\n\n`);
 }
 
 

--- a/scripts/fetch-ci-pr-data.js
+++ b/scripts/fetch-ci-pr-data.js
@@ -31,7 +31,9 @@ const main_branch_url =
   "kata-containers/kata-containers/branches/main";
 
 // The number of checks to fetch from the github API on each paged request.
-const results_per_request = 100;
+// If set to >= the number of jobs, will only need to fetch one page.
+// Could set an upper limit to reduce fetches
+const results_per_request = 500;
 // The last X closed PRs to retrieve
 const pr_count = 10; 
 // Count of the number of fetches

--- a/scripts/fetch-ci-pr-data.js
+++ b/scripts/fetch-ci-pr-data.js
@@ -35,7 +35,7 @@ const results_per_request = 100;
 // The last X closed PRs to retrieve
 const pr_count = 10; 
 // Count of the number of fetches
-// var fetch_count = 0;
+var fetch_count = 0;
 
 
 // Perform a github API request for the last pr_count closed PRs
@@ -166,6 +166,7 @@ function compute_check_stats(prs_with_check_data, required_jobs) {
             // If an existing job includes the new job, the new job is a partial name.
             // Thus, we shouldn't add it
             // console.log("bad new: " + check["name"]);
+            shouldAdd = false;
           }else if(check["name"].includes(existing)){
             // If the new job includes existing job, the existing job is a partial name.
             // Delete it.
@@ -234,9 +235,11 @@ function compute_check_stats(prs_with_check_data, required_jobs) {
       }
     }
     for (const check in check_reruns) { 
-      check_stats[check]["reruns"].push(check_reruns[check]);
-      check_stats[check]["rerun_results"].push(check_rerun_results[check]);
-      check_stats[check]["attempt_urls"].push(check__urls[check]);
+      if (check_stats[check]) {  // Only add if check_stats[check] exists
+        check_stats[check]["reruns"].push(check_reruns[check]);
+        check_stats[check]["rerun_results"].push(check_rerun_results[check]);
+        check_stats[check]["attempt_urls"].push(check__urls[check]);
+      }    
     }
   }
   return check_stats;

--- a/scripts/fetch-ci-pr-data.js
+++ b/scripts/fetch-ci-pr-data.js
@@ -56,7 +56,7 @@ async function fetch_pull_requests() {
     }
   
     const json = await response.json();
-    fetch_count++;
+    fetch_count += 1;
     // console.log(`fetch ${fetch_count}: ${prs_url}
     //     returned PRs cnt: ${Object.keys(json).length}`);
     return json;
@@ -78,7 +78,7 @@ async function fetch_main_branch() {
     }
 
     const json = await response.json();
-    fetch_count++;
+    fetch_count += 1;
     const contexts = json?.protection?.required_status_checks?.contexts;
     // console.log(`fetch ${fetch_count}: ${main_branch_url}
     //     required jobs cnt: ${contexts.length}`);
@@ -103,7 +103,7 @@ function get_check_data(pr) {
     }
 
     const json = await response.json();
-    fetch_count++;
+    fetch_count += 1;
     // console.log(`fetch ${fetch_count}: ${checks_url}
     //     returned check cnt / total cnt: ${json['check_runs'].length} / ${json['total_count']}`);
     return json;
@@ -150,11 +150,32 @@ function get_required_jobs(main_branch) {
   return main_branch["protection"]["required_status_checks"]["contexts"];
 }
 
+// maybe reformat json? less computing on click... more readable
+// fix urls for nightly... broken if reruns
+
+function process_results(result, job_stat){
+  if (result !== "success") {
+    if (result === "skipped") {
+      job_stat["skips"] += 1;
+      job_stat["results"].push("Skip");
+    } else {
+      // failed or cancelled
+      job_stat["fails"] += 1;
+      job_stat["results"].push("Fail");
+    }
+  } else {
+    job_stat["results"].push("Pass");
+  }
+  return job_stat;
+}
+
 
 // Calculate and return check stats across all runs
 function compute_check_stats(prs_with_check_data, required_jobs) {
   const check_stats = {};
   for (const pr of prs_with_check_data) {
+    const check_reruns = {};
+    const check_rerun_results = {};
     for (const check of pr["checks"]) {
         if (!(check["name"] in check_stats)) {
             check_stats[check["name"]] = {
@@ -164,31 +185,67 @@ function compute_check_stats(prs_with_check_data, required_jobs) {
                 urls: [],     // list of PR URLs that this check is associated with
                 results: [],  // list of check statuses for the PRs in which the check was run
                 run_nums: [], // list of PR numbers that this check is associated with
-                reruns: 0,    // the total number of times the test was rerun
+                reruns: [],    // the total number of times the test was rerun
+                rerun_results: [], // an array of strings, e.g. 'Pass', 'Fail', for reruns
             };
         }
         if ((check["name"] in check_stats)) {
             const check_stat = check_stats[check["name"]];
-            check_stat["runs"] += 1;
             check_stat["urls"].push(pr["html_url"])
-            if (check_stat["run_nums"].includes(pr["number"])) {
-                check_stat["reruns"] += 1;
-            }
-            check_stat["run_nums"].push(pr["number"])
-            if (check["conclusion"] != "success") {
-            if (check["conclusion"] == "skipped") {
-                check_stat["skips"] += 1;
-                check_stat["results"].push("Skip");
-            } else {
-                // failed or cancelled
-                check_stat["fails"] += 1;
-                check_stat["results"].push("Fail");
-            }
-            } else {
-            check_stat["results"].push("Pass");
-            }
             check_stat["required"] = required_jobs.includes(check["name"]);
+
+            // If run number is already found, it's a rerun
+            if (check_stat["run_nums"].includes(pr["number"])) {
+              // Increment rerun count for the job. 
+              // check_stat["reruns"] += 1;
+              // console.log(check_stat);
+              // console.log("number: " +pr["number"]);
+
+              // console.log("before results: "+check_rerun_results[check["name"]])
+
+              check_reruns[check["name"]] += 1;
+              // console.log("conclusion: "+check["conclusion"]);
+              // console.log("init results: "+check_rerun_results[check["name"]])
+
+              if (check["conclusion"] != "success") {
+                if (check["conclusion"] == "skipped") {
+                    check_stat["skips"] += 1;
+                    check_rerun_results[check["name"]].push("Skip");
+                } else {
+                    // failed or cancelled
+                    check_stat["fails"] += 1;
+                    check_rerun_results[check["name"]].push("Fail");
+                }
+              } else {
+                check_rerun_results[check["name"]].push("Pass");
+              }
+              // console.log("after results: "+check_rerun_results[check["name"]])
+              // console.log();
+            }else{
+              if(!check_rerun_results[check["name"]]){
+                check_reruns[check["name"]] = 0;
+                check_rerun_results[check["name"]] = [];
+              }
+              check_stat["run_nums"].push(pr["number"]);
+              check_stat["runs"] += 1;
+              if (check["conclusion"] != "success") {
+                if (check["conclusion"] == "skipped") {
+                    check_stat["skips"] += 1;
+                    check_stat["results"].push("Skip");
+                } else {
+                    // failed or cancelled
+                    check_stat["fails"] += 1;
+                    check_stat["results"].push("Fail");
+                }
+              } else {
+                check_stat["results"].push("Pass");
+              }
+            }
         }
+    }
+    for (const check in check_reruns) {
+      check_stats[check]["reruns"].push(check_reruns[check]);
+      check_stats[check]["rerun_results"].push(check_rerun_results[check]);
     }
   }
   return check_stats;

--- a/scripts/fetch-ci-pr-data.js
+++ b/scripts/fetch-ci-pr-data.js
@@ -158,66 +158,82 @@ function compute_check_stats(prs_with_check_data, required_jobs) {
     const check__urls = {};
 
     for (const check of pr["checks"]) {
-        if (!(check["name"] in check_stats)) {
-            check_stats[check["name"]] = {
-                runs: 0,            // e.g. 10, if it ran 10 times
-                fails: 0,           // e.g. 3, if it failed 3 out of 10 times
-                skips: 0,           // e.g. 7, if it got skipped the other 7 times
-                urls: [],           // ordered list of URLs to each PR
-                results: [],        // list of check statuses for the PRs in which the check was run
-                run_nums: [],       // list of PR numbers that this check is associated with
-                reruns: [],         // the total number of times the test was rerun
-                rerun_results: [],  // an array of strings, e.g. 'Pass', 'Fail', for reruns
-                attempt_urls: [],   // ordered list of URLs to each job in a specific PR
-            };
-        }
-        if ((check["name"] in check_stats)) {
-            const check_stat = check_stats[check["name"]];
-            check_stat["required"] = required_jobs.includes(check["name"]);
+      var shouldAdd = true;
+      if (!(check["name"] in check_stats)) {
+          // Check for partial names
+        Object.keys(check_stats).forEach((existing) => {
+          if (existing.includes(check["name"])) {
+            // If an existing job includes the new job, the new job is a partial name.
+            // Thus, we shouldn't add it
+            // console.log("bad new: " + check["name"]);
+          }else if(check["name"].includes(existing)){
+            // If the new job includes existing job, the existing job is a partial name.
+            // Delete it.
+            // console.log("bad existing: " + existing);
+            delete check_stats[existing];
+          }
+        });
+        if(shouldAdd){
+          check_stats[check["name"]] = {
+            runs: 0,            // e.g. 10, if it ran 10 times
+            fails: 0,           // e.g. 3, if it failed 3 out of 10 times
+            skips: 0,           // e.g. 7, if it got skipped the other 7 times
+            urls: [],           // ordered list of URLs to each PR
+            results: [],        // list of check statuses for the PRs in which the check was run
+            run_nums: [],       // list of PR numbers that this check is associated with
+            reruns: [],         // the total number of times the test was rerun
+            rerun_results: [],  // an array of strings, e.g. 'Pass', 'Fail', for reruns
+            attempt_urls: [],   // ordered list of URLs to each job in a specific PR
+          };
+        }   
+      }
+      if (shouldAdd) {
+        const check_stat = check_stats[check["name"]];
+        check_stat["required"] = required_jobs.includes(check["name"]);
 
-            // If run number is already found, it's a rerun
-            if (check_stat["run_nums"].includes(pr["number"])) {
-              // Increment rerun count for the job. 
-              check_reruns[check["name"]] += 1;
-              if (check["conclusion"] != "success") {
-                if (check["conclusion"] == "skipped") {
-                    check_stat["skips"] += 1;
-                    check_rerun_results[check["name"]].push("Skip");
-                } else {
-                    // failed or cancelled
-                    check_stat["fails"] += 1;
-                    check_rerun_results[check["name"]].push("Fail");
-                }
-              } else {
-                check_rerun_results[check["name"]].push("Pass");
-              }
-            }else{
-              // Initilize structures if not initialized before.
-              check_reruns[check["name"]] ??= 0;
-              check_rerun_results[check["name"]] ??= [];
-              check__urls[check["name"]] ??= [];
-              
-              check_stat["run_nums"].push(pr["number"]);
-              check_stat["runs"] += 1;
-              check_stat["urls"].push(pr["html_url"] + "/checks")
-
-              if (check["conclusion"] != "success") {
-                if (check["conclusion"] == "skipped") {
-                    check_stat["skips"] += 1;
-                    check_stat["results"].push("Skip");
-                } else {
-                    // failed or cancelled
-                    check_stat["fails"] += 1;
-                    check_stat["results"].push("Fail");
-                }
-              } else {
-                check_stat["results"].push("Pass");
-              }
+        // If run number is already found, it's a rerun
+        if (check_stat["run_nums"].includes(pr["number"])) {
+          // Increment rerun count for the job. 
+          check_reruns[check["name"]] += 1;
+          if (check["conclusion"] != "success") {
+            if (check["conclusion"] == "skipped") {
+                check_stat["skips"] += 1;
+                check_rerun_results[check["name"]].push("Skip");
+            } else {
+                // failed or cancelled
+                check_stat["fails"] += 1;
+                check_rerun_results[check["name"]].push("Fail");
             }
-            check__urls[check["name"]].push(check["attempt_urls"]);
+          } else {
+            check_rerun_results[check["name"]].push("Pass");
+          }
+        }else{
+          // Initilize structures if not initialized before.
+          check_reruns[check["name"]] ??= 0;
+          check_rerun_results[check["name"]] ??= [];
+          check__urls[check["name"]] ??= [];
+          
+          check_stat["run_nums"].push(pr["number"]);
+          check_stat["runs"] += 1;
+          check_stat["urls"].push(pr["html_url"] + "/checks")
+
+          if (check["conclusion"] != "success") {
+            if (check["conclusion"] == "skipped") {
+                check_stat["skips"] += 1;
+                check_stat["results"].push("Skip");
+            } else {
+                // failed or cancelled
+                check_stat["fails"] += 1;
+                check_stat["results"].push("Fail");
+            }
+          } else {
+            check_stat["results"].push("Pass");
+          }
         }
+        check__urls[check["name"]].push(check["attempt_urls"]);
+      }
     }
-    for (const check in check_reruns) {
+    for (const check in check_reruns) { 
       check_stats[check]["reruns"].push(check_reruns[check]);
       check_stats[check]["rerun_results"].push(check_rerun_results[check]);
       check_stats[check]["attempt_urls"].push(check__urls[check]);

--- a/scripts/fetch-ci-pr-data.js
+++ b/scripts/fetch-ci-pr-data.js
@@ -33,7 +33,7 @@ const main_branch_url =
 // The number of checks to fetch from the github API on each paged request.
 const results_per_request = 100;
 // The last X closed PRs to retrieve
-const pr_count = 20; 
+const pr_count = 10; 
 // Count of the number of fetches
 var fetch_count = 0;
 

--- a/scripts/fetch-ci-pr-data.js
+++ b/scripts/fetch-ci-pr-data.js
@@ -154,7 +154,6 @@ function get_required_jobs(main_branch) {
 // Calculate and return check stats across all runs
 function compute_check_stats(prs_with_check_data, required_jobs) {
   const check_stats = {};
-  const discovered = {};
   for (const pr of prs_with_check_data) {
     for (const check of pr["checks"]) {
         if (!(check["name"] in check_stats)) {
@@ -172,16 +171,8 @@ function compute_check_stats(prs_with_check_data, required_jobs) {
             const check_stat = check_stats[check["name"]];
             check_stat["runs"] += 1;
             check_stat["urls"].push(pr["html_url"])
-            if (!discovered[check["name"]]) {
-              discovered[check["name"]] = new Set();
-            }
             if (check_stat["run_nums"].includes(pr["number"])) {
-              if(discovered[check["name"]].has(pr["number"])){
                 check_stat["reruns"] += 1;
-              } else{
-                discovered[check["name"]].add(pr["number"]);
-                check_stat["reruns"] += 2;
-              }
             }
             check_stat["run_nums"].push(pr["number"])
             if (check["conclusion"] != "success") {

--- a/scripts/fetch-ci-pr-data.js
+++ b/scripts/fetch-ci-pr-data.js
@@ -17,25 +17,25 @@
 const TOKEN = process.env.TOKEN;  // In dev, set by .env file; in prod, set by GitHub Secret
   
 // pull_requests attribute often empty if commit/branch from a fork: https://github.com/orgs/community/discussions/25220
-var pull_requests_url =
+const pull_requests_url =
   "https://api.github.com/repos/" +
   "kata-containers/kata-containers/pulls?state=closed&per_page=";
-var pr_checks_url =  // for our purposes, 'check' refers to a job in the context of a PR
+const pr_checks_url =  // for our purposes, 'check' refers to a job in the context of a PR
   "https://api.github.com/repos/" +
   "kata-containers/kata-containers/commits/";  // will be followed by {commit_sha}/check-runs
   // Max of 100 per page, w/ little *over* 300 checks total, so that's 40 calls total for 10 PRs
 
 // Github API URL for the main branch of the kata-containers repo.
 // Used to get the list of required jobs/checks.
-var main_branch_url = 
+const main_branch_url = 
   "https://api.github.com/repos/" +
   "kata-containers/kata-containers/branches/main";
 
 
 // The number of checks to fetch from the github API on each paged request.
-var results_per_request = 100;
+const results_per_request = 100;
 // The last X closed PRs to retrieve
-var pr_count = 10; 
+const pr_count = 10; 
 // Count of the number of fetches
 var fetch_count = 0;
 
@@ -89,7 +89,7 @@ async function fetch_main_branch() {
 // Perform a github API request for a list of commits for a PR (takes in the PR's head commit SHA)
 function get_check_data(pr) {
   async function fetch_checks_by_page(which_page) {
-    var checks_url = `${pr_checks_url}${prs_with_check_data["commit_sha"]}/check-runs?per_page=${results_per_request}&page=${which_page}`;
+    const checks_url = `${pr_checks_url}${prs_with_check_data["commit_sha"]}/check-runs?per_page=${results_per_request}&page=${which_page}`;
     const response = await fetch(checks_url, {
       headers: {
         Accept: "application/vnd.github+json",
@@ -147,9 +147,7 @@ function get_check_data(pr) {
 
 // Extract list of required jobs (i.e. main branch details: protection: required_status_checks: contexts)
 function get_required_jobs(main_branch) {
-  var required_jobs = main_branch["protection"]["required_status_checks"]["contexts"];
-  // console.log('required jobs: ', required_jobs);
-  return required_jobs;
+  return main_branch["protection"]["required_status_checks"]["contexts"];
 }
 
 
@@ -171,7 +169,7 @@ function compute_check_stats(prs_with_check_data, required_jobs) {
             };
         }
         if ((check["name"] in check_stats)) {
-            var check_stat = check_stats[check["name"]];
+            const check_stat = check_stats[check["name"]];
             check_stat["runs"] += 1;
             check_stat["urls"].push(pr["html_url"])
             if (!discovered[check["name"]]) {
@@ -208,15 +206,15 @@ function compute_check_stats(prs_with_check_data, required_jobs) {
 
 async function main() {
   // Fetch required jobs from main branch
-  var main_branch = await fetch_main_branch();
-  var required_jobs = get_required_jobs(main_branch);
+  const main_branch = await fetch_main_branch();
+  const required_jobs = get_required_jobs(main_branch);
 
   // Fetch recent pull requests via the github API
-  var pull_requests = await fetch_pull_requests();
+  const pull_requests = await fetch_pull_requests();
 
   // Fetch last pr_count closed PRs
   // Store all of this in an array of maps, prs_with_check_data.
-  var promises_buffer = [];
+  const promises_buffer = [];
   for (const pr of pull_requests) {
     promises_buffer.push(get_check_data(pr));
   }
@@ -226,7 +224,7 @@ async function main() {
   // Transform the raw details of each run and its checks' results into a
   // an array of just the checks and their overall results (e.g. pass or fail,
   // and the URLs associated with them).
-  var check_stats = compute_check_stats(prs_with_check_data, required_jobs);
+  const check_stats = compute_check_stats(prs_with_check_data, required_jobs);
 
   // Write the check_stats to console as a JSON object
   console.log(JSON.stringify(check_stats));

--- a/scripts/fetch-ci-pr-data.js
+++ b/scripts/fetch-ci-pr-data.js
@@ -150,9 +150,6 @@ function get_required_jobs(main_branch) {
   return main_branch["protection"]["required_status_checks"]["contexts"];
 }
 
-// maybe reformat json? less computing on click... more readable
-// fix urls for nightly... broken if reruns
-
 function process_results(result, job_stat){
   if (result !== "success") {
     if (result === "skipped") {
@@ -197,16 +194,7 @@ function compute_check_stats(prs_with_check_data, required_jobs) {
             // If run number is already found, it's a rerun
             if (check_stat["run_nums"].includes(pr["number"])) {
               // Increment rerun count for the job. 
-              // check_stat["reruns"] += 1;
-              // console.log(check_stat);
-              // console.log("number: " +pr["number"]);
-
-              // console.log("before results: "+check_rerun_results[check["name"]])
-
               check_reruns[check["name"]] += 1;
-              // console.log("conclusion: "+check["conclusion"]);
-              // console.log("init results: "+check_rerun_results[check["name"]])
-
               if (check["conclusion"] != "success") {
                 if (check["conclusion"] == "skipped") {
                     check_stat["skips"] += 1;
@@ -219,8 +207,6 @@ function compute_check_stats(prs_with_check_data, required_jobs) {
               } else {
                 check_rerun_results[check["name"]].push("Pass");
               }
-              // console.log("after results: "+check_rerun_results[check["name"]])
-              // console.log();
             }else{
               if(!check_rerun_results[check["name"]]){
                 check_reruns[check["name"]] = 0;


### PR DESCRIPTION
The stats were mostly fixed by reporting all of the ~300 checks for each PR (rather than using the list of job names from the Nightly runs).

Did the following:
 - Separated Nightly and PR scripts
 - Aggregated duplicate run nums (with tooltip to show the status of each)
 - Simplified some of the code

Still need to:
 - Only get PRs with ok-to-test label (so keep pulling closed PRs until get 10 with that label)
 - Confirm retrieving reruns of Nightly data

![image](https://github.com/user-attachments/assets/b60c2eeb-e8cb-450c-a43f-63347b314084)
